### PR TITLE
xuantie: nna: select SYNC_FILE

### DIFF
--- a/drivers/soc/xuantie/nna/Kconfig
+++ b/drivers/soc/xuantie/nna/Kconfig
@@ -1,6 +1,7 @@
 menuconfig VHA
        tristate "IMG neural network accelerator"
        default m
+       select SYNC_FILE
 
 if VHA
 choice


### PR DESCRIPTION
fixed: <https://github.com/ruyisdk/linux-xuantie-kernel/issues/214>

KUnit error:
```bash
ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `.L0 ':
vha_common.c:(.text+0x4da): undefined reference to `dma_fence_release'
ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `dma_fence_put.part.0':
vha_common.c:(.text+0x52e): undefined reference to `dma_fence_release'
ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `_vha_in_merged_sync_cb':
vha_common.c:(.text+0x58c): undefined reference to `dma_fence_release'
ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `_vha_in_sync_cb':
vha_common.c:(.text+0x5e4): undefined reference to `dma_fence_release'
ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `.L255':
vha_common.c:(.text+0xe4a): undefined reference to `dma_fence_remove_callback'
ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `.L0 ':
vha_common.c:(.text+0xe96): undefined reference to `dma_fence_release'
ld: vha_common.c:(.text+0xea2): undefined reference to `dma_fence_signal'
ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `.L655':
vha_common.c:(.text+0x28e4): undefined reference to `sync_file_get_fence'
ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `.L659':
vha_common.c:(.text+0x28fc): undefined reference to `dma_fence_add_callback'
ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `.L657':
vha_common.c:(.text+0x295e): undefined reference to `dma_fence_signal'
ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `.L0 ':
vha_common.c:(.text+0x2982): undefined reference to `dma_fence_release'
ld: vha_common.c:(.text+0x2ac4): undefined reference to `dma_fence_release'
ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `.L768':
vha_common.c:(.text+0x2c9e): undefined reference to `dma_fence_context_alloc'
ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `.L0 ':
vha_common.c:(.text+0x2cb0): undefined reference to `dma_fence_array_create'
ld: vha_common.c:(.text+0x2cbe): undefined reference to `sync_file_create'
ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `.L774':
vha_common.c:(.text+0x2ce8): undefined reference to `dma_fence_add_callback'
ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `vha_buf_needs_inval':
vha_common.c:(.text+0x2ec6): undefined reference to `sync_file_get_fence'
ld: vha_common.c:(.text+0x2ee6): undefined reference to `dma_fence_add_callback'
ld: vha_common.c:(.text+0x2f2e): undefined reference to `dma_fence_context_alloc'
ld: vha_common.c:(.text+0x2f40): undefined reference to `dma_fence_array_create'
ld: vha_common.c:(.text+0x2f52): undefined reference to `sync_file_create'
ld: vha_common.c:(.text+0x2f7c): undefined reference to `dma_fence_add_callback'
ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `.L812':
vha_common.c:(.text+0x2fbe): undefined reference to `dma_fence_signal'
ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `.L0 ':
vha_common.c:(.text+0x2ffe): undefined reference to `sync_file_get_fence'
ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `vha_create_output_sync':
vha_common.c:(.text+0x3038): undefined reference to `dma_fence_add_callback'
ld: vha_common.c:(.text+0x308a): undefined reference to `dma_fence_signal'
ld: drivers/soc/xuantie/nna/img_mem/img_mem_man.o: in function `.L229':
img_mem_man.c:(.text+0xba4): undefined reference to `dma_fence_context_alloc'
ld: drivers/soc/xuantie/nna/img_mem/img_mem_man.o: in function `.L231':
img_mem_man.c:(.text+0xbbe): undefined reference to `dma_fence_init'
ld: drivers/soc/xuantie/nna/img_mem/img_mem_man.o: in function `.L248':
img_mem_man.c:(.text+0xc5c): undefined reference to `dma_fence_free'
ld: drivers/soc/xuantie/nna/img_mem/img_mem_man.o: in function `.L0 ':
img_mem_man.c:(.text+0xcaa): undefined reference to `dma_fence_signal'
ld: img_mem_man.c:(.text+0x1872): undefined reference to `dma_fence_signal'
ld: drivers/soc/xuantie/nna/img_mem/img_mem_man.o: in function `.LANCHOR2':
img_mem_man.c:(.data+0x28): undefined reference to `dma_fence_default_wait'
ld: drivers/soc/xuantie/nna/img_mem/img_mem_carveout.o: in function `carveout_heap_free':
img_mem_carveout.c:(.text+0x1b2): undefined reference to `dma_buf_put'
ld: drivers/soc/xuantie/nna/img_mem/img_mem_carveout.o: in function `.L0 ':
img_mem_carveout.c:(.text+0x2c4): undefined reference to `dma_buf_export'
ld: img_mem_carveout.c:(.text+0x2e0): undefined reference to `dma_buf_fd'
ld: img_mem_carveout.c:(.text+0x42e): undefined reference to `dma_buf_put'
ld: drivers/soc/xuantie/nna/img_mem/img_mem_unified.o: in function `.L0 ':
img_mem_unified.c:(.text+0x356): undefined reference to `dma_buf_export'
ld: img_mem_unified.c:(.text+0x374): undefined reference to `dma_buf_fd'
ld: drivers/soc/xuantie/nna/img_mem/img_mem_unified.o: in function `.L80':
img_mem_unified.c:(.text+0x3ca): undefined reference to `dma_buf_put'
ld: drivers/soc/xuantie/nna/img_mem/img_mem_unified.o: in function `unified_end_cpu_access_dmabuf':
img_mem_unified.c:(.text+0xa28): undefined reference to `dma_buf_put'
ld: drivers/soc/xuantie/video_memory/video_memory.o: in function `.L124':
video_memory.c:(.text+0x5ce): undefined reference to `dma_buf_unmap_attachment'
ld: drivers/soc/xuantie/video_memory/video_memory.o: in function `.L112':
video_memory.c:(.text+0x5da): undefined reference to `dma_buf_detach'
ld: drivers/soc/xuantie/video_memory/video_memory.o: in function `.L151':
video_memory.c:(.text+0x5e4): undefined reference to `dma_buf_put'
ld: drivers/soc/xuantie/video_memory/video_memory.o: in function `.L431':
video_memory.c:(.text+0x104a): undefined reference to `dma_buf_get'
ld: drivers/soc/xuantie/video_memory/video_memory.o: in function `.L395':
video_memory.c:(.text+0x1066): undefined reference to `dma_buf_attach'
ld: video_memory.c:(.text+0x1076): undefined reference to `dma_buf_map_attachment'
ld: drivers/soc/xuantie/video_memory/video_memory.o: in function `.L0 ':
video_memory.c:(.text+0x121e): undefined reference to `dma_buf_fd'
ld: drivers/soc/xuantie/video_memory/video_memory.o: in function `.L392':
video_memory.c:(.text+0x1398): undefined reference to `dma_buf_export'
ld: drivers/soc/xuantie/video_memory/video_memory.o: in function `.L412':
video_memory.c:(.text+0x13cc): undefined reference to `dma_buf_unmap_attachment'
make[3]: *** [../scripts/Makefile.vmlinux:37: vmlinux] Error 1
make[2]: *** [/home/jenkins/agent/workspace/rvck-debug-test/kunit-test/work/Makefile:1172: vmlinux] Error 2
make[1]: *** [/home/jenkins/agent/workspace/rvck-debug-test/kunit-test/work/Makefile:234: __sub-make] Error 2
make: *** [Makefile:234: __sub-make] Error 2
```