### PR TITLE
Optimization of the assembly code of uaccess APIs.

### DIFF
--- a/arch/riscv/lib/uaccess.S
+++ b/arch/riscv/lib/uaccess.S
@@ -95,7 +95,7 @@ ENTRY(__asm_copy_from_user)
 	fixup REG_S   t4,  7*SZREG(a0), 10f
 	addi	a0, a0, 8*SZREG
 	addi	a1, a1, 8*SZREG
-	bltu	a0, t0, 2b
+	bleu	a0, t0, 2b
 
 	addi	t0, t0, 8*SZREG /* revert to original value */
 	j	.Lbyte_copy_tail

--- a/arch/riscv/lib/uaccess.S
+++ b/arch/riscv/lib/uaccess.S
@@ -36,7 +36,7 @@ ENTRY(__asm_copy_from_user)
 	 * Use byte copy only if too small.
 	 * SZREG holds 4 for RV32 and 8 for RV64
 	 */
-	li	a3, 9*SZREG /* size must be larger than size in word_copy */
+	li	a3, 9*SZREG-1 /* size must >= (word_copy stride + SZREG-1) */
 	bltu	a2, a3, .Lbyte_copy_tail
 
 	/*


### PR DESCRIPTION
fixed: #112

合入了两个uaccess优化代码，提示uaccess性能

riscv: uaccess: Relax the threshold for fast path
具体含义：该补丁放宽了 RISC-V 架构下用户空间访问（uaccess）快速路径的阈值。在用户空间和内核空间进行数据拷贝时，如果数据对齐情况不佳，需要先拷贝未对齐的头部数据。原本的阈值设置较小，导致一些情况下即使数据量不大，也会进入慢速路径，影响效率。此补丁将阈值设置为大于等于 SZREG−1+word_copystridesize，即 9∗SZREG−1，其中 SZREG 是寄存器大小。

riscv: uaccess: Allow the last potential unrolled copy
具体含义：：在某些情况下，如果目标缓冲区的最后一个对齐地址处还有剩余的数据需要拷贝，此补丁允许继续进行展开拷贝，而不是直接停止拷贝，这样可以充分利用展开拷贝的性能优势，进一步提高数据拷贝的效率。

这里主要使用access边界测试和非对齐测试，看看uaccess是否返回值正确，参考
[uaccess_test1.c](https://github.com/user-attachments/files/22113352/uaccess_test1.c)
[uaccess_test2.c](https://github.com/user-attachments/files/22113353/uaccess_test2.c)
