### PR TITLE
riscv: dp1000: update pcie driver and add dp1000-mo-v1.dts

### DIFF
--- a/arch/riscv/boot/dts/ultrarisc/Makefile
+++ b/arch/riscv/boot/dts/ultrarisc/Makefile
@@ -1,2 +1,4 @@
 # SPDX-License-Identifier: GPL-2.0
-dtb-y += dp1000.dtb dp1000-evb-v1.dtb
+dtb-$(CONFIG_ARCH_ULTRARISC) += dp1000.dtb
+dtb-$(CONFIG_ARCH_ULTRARISC) += dp1000-evb-v1.dtb
+dtb-$(CONFIG_ARCH_ULTRARISC) += dp1000-mo-v1.dtb

--- a/arch/riscv/boot/dts/ultrarisc/dp1000-evb-pinctrl.dtsi
+++ b/arch/riscv/boot/dts/ultrarisc/dp1000-evb-pinctrl.dtsi
@@ -71,8 +71,8 @@
 
 			uart0_pins: uart0_pins {
 				pinctrl-pins = <
-				UR_DP1000_IOMUX_A  8  UR_FUNC0
-				UR_DP1000_IOMUX_A  9  UR_FUNC0
+				UR_DP1000_IOMUX_A  8  UR_FUNC1
+				UR_DP1000_IOMUX_A  9  UR_FUNC1
 				>;
 
 				pinconf-pins = <

--- a/arch/riscv/boot/dts/ultrarisc/dp1000-evb-v1.dts
+++ b/arch/riscv/boot/dts/ultrarisc/dp1000-evb-v1.dts
@@ -28,6 +28,14 @@
 &spi0 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi0_pins>;
+
+	mmc0: mmc@0 {
+		compatible = "mmc-spi-slot";
+		spi-max-frequency = <15625000>;
+		reg = <0x00>;
+		voltage-ranges = <3300 3300>;
+		disable-wp;
+	};
 };
 
 &spi1 {

--- a/arch/riscv/boot/dts/ultrarisc/dp1000-mo-pinctrl.dtsi
+++ b/arch/riscv/boot/dts/ultrarisc/dp1000-mo-pinctrl.dtsi
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright(C) 2025 UltraRISC Technology (Shanghai) Co., Ltd.
+ */
+
+#include <dt-bindings/pinctrl/ur-dp1000-pinctrl.h>
+
+/ {
+
+	soc {
+		pmx0: pinmux@11081000 {
+			compatible = "ultrarisc,dp1000-pinctrl";
+			reg = <0x0 0x11081000  0x0 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			#pinctrl-cells = <2>;
+			pinctrl-single,register-width = <32>;
+			pinctrl-single,function-mask = <0x3ff>;
+			pinctrl-use-default;
+
+			i2c0_pins: i2c0_pins {
+				pinctrl-pins = <
+				UR_DP1000_IOMUX_A  12  UR_FUNC0
+				UR_DP1000_IOMUX_A  13  UR_FUNC0
+				>;
+
+				pinconf-pins = <
+				UR_DP1000_IOMUX_A  12  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				UR_DP1000_IOMUX_A  13  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				>;
+			};
+
+			i2c1_pins: i2c1_pins {
+				pinctrl-pins = <
+				UR_DP1000_IOMUX_B  6  UR_FUNC0
+				UR_DP1000_IOMUX_B  7  UR_FUNC0
+				>;
+
+				pinconf-pins = <
+				UR_DP1000_IOMUX_B  6  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				UR_DP1000_IOMUX_B  7  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				>;
+			};
+
+			i2c2_pins: i2c2_pins {
+				pinctrl-pins = <
+				UR_DP1000_IOMUX_C  0  UR_FUNC0
+				UR_DP1000_IOMUX_C  1  UR_FUNC0
+				>;
+
+				pinconf-pins = <
+				UR_DP1000_IOMUX_C  0  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				UR_DP1000_IOMUX_C  1  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				>;
+			};
+
+			i2c3_pins: i2c3_pins {
+				pinctrl-pins = <
+				UR_DP1000_IOMUX_C  2  UR_FUNC0
+				UR_DP1000_IOMUX_C  3  UR_FUNC0
+				>;
+
+				pinconf-pins = <
+				UR_DP1000_IOMUX_C  2  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				UR_DP1000_IOMUX_C  3  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				>;
+			};
+
+			uart0_pins: uart0_pins {
+				pinctrl-pins = <
+				UR_DP1000_IOMUX_A  8  UR_FUNC1
+				UR_DP1000_IOMUX_A  9  UR_FUNC1
+				>;
+
+				pinconf-pins = <
+				UR_DP1000_IOMUX_A  8  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				UR_DP1000_IOMUX_A  9  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				>;
+			};
+
+			uart1_pins: uart1_pins {
+				pinctrl-pins = <
+				UR_DP1000_IOMUX_B  4  UR_FUNC0
+				UR_DP1000_IOMUX_B  5  UR_FUNC0
+				>;
+
+				pinconf-pins = <
+				UR_DP1000_IOMUX_B  4  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				UR_DP1000_IOMUX_B  5  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				>;
+			};
+
+			uart2_pins: uart2_pins {
+				pinctrl-pins = <
+				UR_DP1000_IOMUX_C  4  UR_FUNC0
+				UR_DP1000_IOMUX_C  5  UR_FUNC0
+				>;
+
+				pinconf-pins = <
+				UR_DP1000_IOMUX_C  4  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				UR_DP1000_IOMUX_C  5  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				>;
+			};
+
+			spi0_pins: spi0_pins {
+				pinctrl-pins = <
+				UR_DP1000_IOMUX_D  0  UR_FUNC1
+				UR_DP1000_IOMUX_D  1  UR_FUNC1
+				UR_DP1000_IOMUX_D  2  UR_FUNC1
+				UR_DP1000_IOMUX_D  3  UR_FUNC1
+				UR_DP1000_IOMUX_D  4  UR_FUNC1
+				UR_DP1000_IOMUX_D  5  UR_FUNC1
+				UR_DP1000_IOMUX_D  6  UR_FUNC1
+				UR_DP1000_IOMUX_D  7  UR_FUNC1
+				>;
+
+				pinconf-pins = <
+				UR_DP1000_IOMUX_D  0  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				UR_DP1000_IOMUX_D  1  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				UR_DP1000_IOMUX_D  2  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				UR_DP1000_IOMUX_D  3  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				UR_DP1000_IOMUX_D  4  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				UR_DP1000_IOMUX_D  5  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				UR_DP1000_IOMUX_D  6  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				UR_DP1000_IOMUX_D  7  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				>;
+			};
+
+			spi1_pins: spi1_pins {
+				pinctrl-pins = <
+				UR_DP1000_IOMUX_A  0  UR_FUNC0
+				UR_DP1000_IOMUX_A  1  UR_FUNC0
+				UR_DP1000_IOMUX_A  2  UR_FUNC0
+				UR_DP1000_IOMUX_A  3  UR_FUNC0
+				>;
+
+				pinconf-pins = <
+				UR_DP1000_IOMUX_A  0  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				UR_DP1000_IOMUX_A  1  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				UR_DP1000_IOMUX_A  2  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				UR_DP1000_IOMUX_A  3  UR_DP1000_BIAS(UR_PULL_UP, UR_DRIVE_DEF)
+				>;
+			};
+		};
+	};
+};

--- a/arch/riscv/boot/dts/ultrarisc/dp1000-mo-v1.dts
+++ b/arch/riscv/boot/dts/ultrarisc/dp1000-mo-v1.dts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright(C) 2025 UltraRISC Technology (Shanghai) Co., Ltd.
+ */
+
+#include "dp1000.dts"
+#include "dp1000-mo-pinctrl.dtsi"
+#include <dt-bindings/iio/temperature/thermocouple.h>
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0_pins>;
+};
+
+&i2c1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c1_pins>;
+};
+
+&i2c2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c2_pins>;
+
+	rtc@32 {
+		compatible = "whwave,sd3078";
+		reg = <0x32>;
+	};
+};
+
+&i2c3 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c3_pins>;
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_pins>;
+};
+
+&spi1 {
+	num-cs = <1>;
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi1_pins>;
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
+};
+
+&uart1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart1_pins>;
+};
+
+&uart2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart2_pins>;
+};

--- a/arch/riscv/boot/dts/ultrarisc/dp1000.dts
+++ b/arch/riscv/boot/dts/ultrarisc/dp1000.dts
@@ -258,13 +258,6 @@
 			clock-names = "device_clk";
 			num-cs = <3>;
 			spi-max-frequency = <62500000>;
-			mmc0: mmc@0 {
-				compatible = "mmc-spi-slot";
-				spi-max-frequency = <15625000>;
-				reg = <0x00>;
-				voltage-ranges = <3300 3300>;
-				disable-wp;
-			};
 		};
 
 		spi1: spi@20420000 {

--- a/drivers/pci/controller/dwc/pcie-designware-host.c
+++ b/drivers/pci/controller/dwc/pcie-designware-host.c
@@ -675,13 +675,8 @@ EXPORT_SYMBOL_GPL(dw_pcie_own_conf_map_bus);
 
 static struct pci_ops dw_pcie_ops = {
 	.map_bus = dw_pcie_own_conf_map_bus,
-#if IS_ENABLED(CONFIG_PCIE_ULTRARISC)
-	.read = pci_generic_config_read32,
-	.write = pci_generic_config_write32,
-#else
 	.read = pci_generic_config_read,
 	.write = pci_generic_config_write,
-#endif
 };
 
 /**

--- a/drivers/pci/controller/dwc/pcie-designware.c
+++ b/drivers/pci/controller/dwc/pcie-designware.c
@@ -762,6 +762,10 @@ static void dw_pcie_link_set_max_link_width(struct dw_pcie *pci, u32 num_lanes)
 	case 8:
 		plc |= PORT_LINK_MODE_8_LANES;
 		break;
+	case 16:
+		plc |= PORT_LINK_MODE_16_LANES;
+		lwsc |= PORT_LOGIC_LINK_WIDTH_16_LANES;
+		break;
 	default:
 		dev_err(pci->dev, "num-lanes %u: invalid value\n", num_lanes);
 		return;

--- a/drivers/pci/controller/dwc/pcie-ultrarisc.c
+++ b/drivers/pci/controller/dwc/pcie-ultrarisc.c
@@ -33,7 +33,24 @@ struct ultrarisc_pcie {
 
 static const struct of_device_id ultrarisc_pcie_of_match[];
 
+static struct pci_ops ultrarisc_pci_ops = {
+	.map_bus = dw_pcie_own_conf_map_bus,
+	.read = pci_generic_config_read32,
+	.write = pci_generic_config_write32,
+};
+
+static int ultrarisc_pcie_host_init(struct dw_pcie_rp *pp)
+{
+	struct pci_host_bridge *bridge = pp->bridge;
+
+	/* Set the bus ops */
+	bridge->ops = &ultrarisc_pci_ops;
+
+	return 0;
+}
+
 static const struct dw_pcie_host_ops ultrarisc_pcie_host_ops = {
+	.host_init = ultrarisc_pcie_host_init,
 };
 
 static int ultrarisc_pcie_establish_link(struct dw_pcie *pci)
@@ -73,7 +90,7 @@ static int ultrarisc_pcie_establish_link(struct dw_pcie *pci)
 	return 0;
 }
 
-static const struct dw_pcie_ops ultrarisc_pcie_ops = {
+static const struct dw_pcie_ops dw_pcie_ops = {
 	.start_link = ultrarisc_pcie_establish_link,
 };
 
@@ -94,7 +111,7 @@ static int ultrarisc_pcie_probe(struct platform_device *pdev)
 		return -ENOMEM;
 
 	pci->dev = dev;
-	pci->ops = &ultrarisc_pcie_ops;
+	pci->ops = &dw_pcie_ops;
 
 	/* Set a default value suitable for at most 16 in and 16 out windows */
 	pci->atu_size = SZ_8K;


### PR DESCRIPTION
Fixed: #71

updates to PCIe drivers and device tree files for the UltraRISC DP1000 platform.

The changes enhance PCIe functionality with support for 16-lane link width, 
introduce custom host operations for the UltraRISC PCIe controller, 
and include device tree improvements such as adding support for the dp1000-mo-v1 
board and moving board-specific components to appropriate files.

All updates have been tested on the UltraRISC DP1000 platform to ensure correct functionality.