### PR TITLE
riscv: drm: img-rogue: Convert structure initializations to designated initializers

### DIFF
--- a/drivers/gpu/drm/img-rogue/physmem_hostmem.c
+++ b/drivers/gpu/drm/img-rogue/physmem_hostmem.c
@@ -66,9 +66,9 @@ static void HostMemDevPAddrToCpuPAddr(IMG_HANDLE hPrivData,
 static PHYS_HEAP_FUNCTIONS gsHostMemDevPhysHeapFuncs =
 {
 	/* pfnCpuPAddrToDevPAddr */
-	HostMemCpuPAddrToDevPAddr,
+	.pfnCpuPAddrToDevPAddr = HostMemCpuPAddrToDevPAddr,
 	/* pfnDevPAddrToCpuPAddr */
-	HostMemDevPAddrToCpuPAddr,
+	.pfnDevPAddrToCpuPAddr = HostMemDevPAddrToCpuPAddr
 };
 
 static PVRSRV_DEVICE_CONFIG gsHostMemDevConfig[];

--- a/drivers/gpu/drm/img-rogue/physmem_lma.c
+++ b/drivers/gpu/drm/img-rogue/physmem_lma.c
@@ -1843,31 +1843,31 @@ PVRSRV_ERROR PMRChangeSparseMemCPUMapLocalMem(PMR_IMPL_PRIVDATA pPriv,
 
 static PMR_IMPL_FUNCTAB _sPMRLMAFuncTab = {
 	/* pfnLockPhysAddresses */
-	&PMRLockSysPhysAddressesLocalMem,
+	.pfnLockPhysAddresses = &PMRLockSysPhysAddressesLocalMem,
 	/* pfnUnlockPhysAddresses */
-	&PMRUnlockSysPhysAddressesLocalMem,
+	.pfnUnlockPhysAddresses = &PMRUnlockSysPhysAddressesLocalMem,
 	/* pfnDevPhysAddr */
-	&PMRSysPhysAddrLocalMem,
+	.pfnDevPhysAddr = &PMRSysPhysAddrLocalMem,
 	/* pfnAcquireKernelMappingData */
-	&PMRAcquireKernelMappingDataLocalMem,
+	.pfnAcquireKernelMappingData = &PMRAcquireKernelMappingDataLocalMem,
 	/* pfnReleaseKernelMappingData */
-	&PMRReleaseKernelMappingDataLocalMem,
+	.pfnReleaseKernelMappingData = &PMRReleaseKernelMappingDataLocalMem,
 	/* pfnReadBytes */
-	&PMRReadBytesLocalMem,
+	.pfnReadBytes = &PMRReadBytesLocalMem,
 	/* pfnWriteBytes */
-	&PMRWriteBytesLocalMem,
+	.pfnWriteBytes = &PMRWriteBytesLocalMem,
 	/* pfnUnpinMem */
-	NULL,
+	.pfnUnpinMem = NULL,
 	/* pfnPinMem */
-	NULL,
+	.pfnPinMem = NULL,
 	/* pfnChangeSparseMem*/
-	&PMRChangeSparseMemLocalMem,
+	.pfnChangeSparseMem = &PMRChangeSparseMemLocalMem,
 	/* pfnChangeSparseMemCPUMap */
-	&PMRChangeSparseMemCPUMapLocalMem,
+	.pfnChangeSparseMemCPUMap = &PMRChangeSparseMemCPUMapLocalMem,
 	/* pfnMMap */
-	NULL,
+	.pfnMMap = NULL,
 	/* pfnFinalize */
-	&PMRFinalizeLocalMem
+	.pfnFinalize = &PMRFinalizeLocalMem
 };
 
 PVRSRV_ERROR

--- a/drivers/gpu/drm/img-rogue/sysconfig.c
+++ b/drivers/gpu/drm/img-rogue/sysconfig.c
@@ -151,9 +151,9 @@ void UMAPhysHeapDevPAddrToCpuPAddr(IMG_HANDLE hPrivData,
 static PHYS_HEAP_FUNCTIONS gsPhysHeapFuncs =
 {
 	/* pfnCpuPAddrToDevPAddr */
-	UMAPhysHeapCpuPAddrToDevPAddr,
+	.pfnCpuPAddrToDevPAddr = UMAPhysHeapCpuPAddrToDevPAddr,
 	/* pfnDevPAddrToCpuPAddr */
-	UMAPhysHeapDevPAddrToCpuPAddr,
+	.pfnDevPAddrToCpuPAddr = UMAPhysHeapDevPAddrToCpuPAddr,
 };
 
 static PVRSRV_ERROR PhysHeapsCreate(PHYS_HEAP_CONFIG **ppasPhysHeapsOut,

--- a/drivers/gpu/drm/img-rogue/vmm_type_stub.c
+++ b/drivers/gpu/drm/img-rogue/vmm_type_stub.c
@@ -75,29 +75,29 @@ static VMM_PVZ_CONNECTION gsStubVmmPvz =
 {
 	.sClientFuncTab = {
 		/* pfnMapDevPhysHeap */
-		&StubVMMMapDevPhysHeap,
+		.pfnMapDevPhysHeap = &StubVMMMapDevPhysHeap,
 
 		/* pfnUnmapDevPhysHeap */
-		&StubVMMUnmapDevPhysHeap
+		.pfnUnmapDevPhysHeap = &StubVMMUnmapDevPhysHeap
 	},
 
 	.sServerFuncTab = {
 		/* pfnMapDevPhysHeap */
-		&PvzServerMapDevPhysHeap,
+		.pfnMapDevPhysHeap = &PvzServerMapDevPhysHeap,
 
 		/* pfnUnmapDevPhysHeap */
-		&PvzServerUnmapDevPhysHeap
+		.pfnUnmapDevPhysHeap = &PvzServerUnmapDevPhysHeap
 	},
 
 	.sVmmFuncTab = {
 		/* pfnOnVmOnline */
-		&PvzServerOnVmOnline,
+		.pfnOnVmOnline = &PvzServerOnVmOnline,
 
 		/* pfnOnVmOffline */
-		&PvzServerOnVmOffline,
+		.pfnOnVmOffline = &PvzServerOnVmOffline,
 
 		/* pfnVMMConfigure */
-		&PvzServerVMMConfigure
+		.pfnVMMConfigure = &PvzServerVMMConfigure
 	}
 };
 


### PR DESCRIPTION
fixed: #136

community inclusion
category: bugfix
bugzilla: https://github.com/RVCK-Project/rvck/issues/136

--------------------------------

When cross-compiling with riscv64-unknown-linux-gnu-gcc
(g04696df0963) 14.2.0, the compiler enforces the use of
designated initializers with -Werror=designated-init.
Convert the structure initializations from positional
to designated initializers to comply with this
requirement and avoid build errors.