### PR TITLE
perf vendor events riscv: add lrw core JSON file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -12416,6 +12416,12 @@ S:	Maintained
 F:	Documentation/devicetree/bindings/thermal/loongson,ls2k-thermal.yaml
 F:	drivers/thermal/loongson2_thermal.c
 
+LRW CORE PERF PMU EVENTS (RISC-V)
+M:	Lin Shen <shen.lin1@zte.com.cn>
+R:	Qingtao Liu <liu.qingtao2@zte.com.cn>
+S:	Maintained
+F:	tools/perf/pmu-events/arch/riscv/lrw/
+
 LSILOGIC MPT FUSION DRIVERS (FC/SAS/SPI)
 M:	Sathya Prakash <sathya.prakash@broadcom.com>
 M:	Sreekanth Reddy <sreekanth.reddy@broadcom.com>

--- a/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/branch.json
+++ b/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/branch.json
@@ -1,0 +1,77 @@
+[
+    {
+        "EventName": "BR_MIS_PRED",
+        "EventCode": "0x00000109",
+        "BriefDescription": "Mispredicted or not predicted branch speculatively executed"
+    },
+    {
+        "EventName": "BR_PRED",
+        "EventCode": "0x00000209",
+        "BriefDescription": "Predictable branch speculatively executed"
+    },
+    {
+        "EventName": "BR_RETIRED",
+        "EventCode": "0x00000409",
+        "BriefDescription": "Branch instruction architecturally executed"
+    },
+    {
+        "EventName": "BR_MIS_PRED_RETIRED",
+        "EventCode": "0x00000809",
+        "BriefDescription": "Mispredicted branch instruction architecturally executed"
+    },
+    {
+        "EventName": "BR_IMMED_SPEC",
+        "EventCode": "0x00001009",
+        "BriefDescription": "Branch immediate instructions speculatively executed"
+    },
+    {
+        "EventName": "BR_RETURN_SPEC",
+        "EventCode": "0x00002009",
+        "BriefDescription": "Procedure return instruction speculatively executed"
+    },
+    {
+        "EventName": "BR_INDIRECT_SPEC",
+        "EventCode": "0x00004009",
+        "BriefDescription": "Indirect branch instruction speculatively executed"
+    },
+    {
+        "EventName": "BR_PRED_BTB_RGN_UPDATE",
+        "EventCode": "0x00008009",
+        "BriefDescription": "Branch prediction branch target buffer region update"
+    },
+    {
+        "EventName": "SPEC_RET_STACK_FULL",
+        "EventCode": "0x00010009",
+        "BriefDescription": "Speculative return stack full"
+    },
+    {
+        "EventName": "FETCH_FQ_EMPTY",
+        "EventCode": "0x00020009",
+        "BriefDescription": "Fetch queue empty"
+    },
+    {
+        "EventName": "FETCH_MCACHE_INVALIDATE",
+        "EventCode": "0x00040009",
+        "BriefDescription": "Fetch mopcache invalidate"
+    },
+    {
+        "EventName": "FETCH_MCACHE_ICACHE_SWITCH",
+        "EventCode": "0x00080009",
+        "BriefDescription": "Fetch mopcache instruction cache switch"
+    },
+    {
+        "EventName": "FETCH_MCACHE_ICACHE_SWITCH_PENALTY",
+        "EventCode": "0x00100009",
+        "BriefDescription": "Fetch mopcache instruction cache switch penalty"
+    },
+    {
+        "EventName": "BR_PRED_BTB_RGN_UPDATE_NREADY",
+        "EventCode": "0x00200009",
+        "BriefDescription": "Branch prediction branch target buffer region update not ready"
+    },
+    {
+        "EventName": "BR_PRED_BTB_CTX_UPDATE",
+        "EventCode": "0x00400009",
+        "BriefDescription": "Branch prediction branch target buffer context update"
+    }
+]

--- a/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/exception.json
+++ b/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/exception.json
@@ -1,0 +1,102 @@
+[
+    {
+        "EventName": "EXC_TAKEN",
+        "EventCode": "0x0000010a",
+        "BriefDescription": "Exception taken"
+    },
+    {
+        "EventName": "EXC_RETURN",
+        "EventCode": "0x0000020a",
+        "BriefDescription": "Exception return"
+    },
+    {
+        "EventName": "EXC_UNDEF",
+        "EventCode": "0x0000040a",
+        "BriefDescription": "Undefined exception taken locally"
+    },
+    {
+        "EventName": "EXC_ECALL_U",
+        "EventCode": "0x0000080a",
+        "BriefDescription": "User Call exception taken locally"
+    },
+    {
+        "EventName": "EXC_PABORT",
+        "EventCode": "0x0000100a",
+        "BriefDescription": "Instruction abort exception taken locally"
+    },
+    {
+        "EventName": "EXC_DABORT",
+        "EventCode": "0x0000200a",
+        "BriefDescription": "Data abort or SError taken locally"
+    },
+    {
+        "EventName": "EXC_IRQ",
+        "EventCode": "0x0000400a",
+        "BriefDescription": "IRQ exception taken locally"
+    },
+    {
+        "EventName": "EXC_FIQ",
+        "EventCode": "0x0000800a",
+        "BriefDescription": "FIQ exception taken locally"
+    },
+    {
+        "EventName": "EXC_ECALL_M",
+        "EventCode": "0x0001000a",
+        "BriefDescription": "M-mode Call exception"
+    },
+    {
+        "EventName": "EXC_ECALL_S",
+        "EventCode": "0x0002000a",
+        "BriefDescription": "S-mode Call exception"
+    },
+    {
+        "EventName": "EXC_TRAP_PABORT",
+        "EventCode": "0x0004000a",
+        "BriefDescription": "Instruction abort exception not taken locally"
+    },
+    {
+        "EventName": "EXC_TRAP_DABORT",
+        "EventCode": "0x0008000a",
+        "BriefDescription": "Data abort or SError not taken locally"
+    },
+    {
+        "EventName": "EXC_ECALL_VS",
+        "EventCode": "0x0010000a",
+        "BriefDescription": "VS-mode Call exception"
+    },
+    {
+        "EventName": "EXC_TRAP_IRQ",
+        "EventCode": "0x0020000a",
+        "BriefDescription": "IRQ exception not taken locally"
+    },
+    {
+        "EventName": "EXC_TRAP_FIQ",
+        "EventCode": "0x0040000a",
+        "BriefDescription": "FIQ exception not taken locally"
+    },
+    {
+        "EventName": "FLUSH",
+        "EventCode": "0x0080000a",
+        "BriefDescription": "Flush"
+    },
+    {
+        "EventName": "FLUSH_MEM",
+        "EventCode": "0x0100000a",
+        "BriefDescription": "Access memory flush"
+    },
+    {
+        "EventName": "FLUSH_ISB",
+        "EventCode": "0x0400000a",
+        "BriefDescription": "Flush Instruction Synchronization Barrier"
+    },
+    {
+        "EventName": "FLUSH_OTHER",
+        "EventCode": "0x0800000a",
+        "BriefDescription": "Flush Other"
+    },
+    {
+        "EventName": "FLUSH_BAD_BRANCH",
+        "EventCode": "0x1000000a",
+        "BriefDescription": "Flush Bad Branch"
+    }
+]

--- a/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/firmware.json
+++ b/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/firmware.json
@@ -1,0 +1,68 @@
+[
+  {
+    "ArchStdEvent": "FW_MISALIGNED_LOAD"
+  },
+  {
+    "ArchStdEvent": "FW_MISALIGNED_STORE"
+  },
+  {
+    "ArchStdEvent": "FW_ACCESS_LOAD"
+  },
+  {
+    "ArchStdEvent": "FW_ACCESS_STORE"
+  },
+  {
+    "ArchStdEvent": "FW_ILLEGAL_INSN"
+  },
+  {
+    "ArchStdEvent": "FW_SET_TIMER"
+  },
+  {
+    "ArchStdEvent": "FW_IPI_SENT"
+  },
+  {
+    "ArchStdEvent": "FW_IPI_RECEIVED"
+  },
+  {
+    "ArchStdEvent": "FW_FENCE_I_SENT"
+  },
+  {
+    "ArchStdEvent": "FW_FENCE_I_RECEIVED"
+  },
+  {
+    "ArchStdEvent": "FW_SFENCE_VMA_SENT"
+  },
+  {
+    "ArchStdEvent": "FW_SFENCE_VMA_RECEIVED"
+  },
+  {
+    "ArchStdEvent": "FW_SFENCE_VMA_ASID_SENT"
+  },
+  {
+    "ArchStdEvent": "FW_SFENCE_VMA_ASID_RECEIVED"
+  },
+  {
+    "ArchStdEvent": "FW_HFENCE_GVMA_SENT"
+  },
+  {
+    "ArchStdEvent": "FW_HFENCE_GVMA_RECEIVED"
+  },
+  {
+    "ArchStdEvent": "FW_HFENCE_GVMA_VMID_SENT"
+  },
+  {
+    "ArchStdEvent": "FW_HFENCE_GVMA_VMID_RECEIVED"
+  },
+  {
+    "ArchStdEvent": "FW_HFENCE_VVMA_SENT"
+  },
+  {
+    "ArchStdEvent": "FW_HFENCE_VVMA_RECEIVED"
+  },
+  {
+    "ArchStdEvent": "FW_HFENCE_VVMA_ASID_SENT"
+  },
+  {
+    "ArchStdEvent": "FW_HFENCE_VVMA_ASID_RECEIVED"
+  }
+]

--- a/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/general_cpu.json
+++ b/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/general_cpu.json
@@ -1,0 +1,12 @@
+[
+    {
+        "EventName": "CID_WRITE_RETIRED",
+        "EventCode": "0x0000020b",
+        "BriefDescription": "CONTEXTIDR register write"
+    },
+    {
+        "EventName": "CPU_CYCLES",
+        "EventCode": "0x0000040b",
+        "BriefDescription": "cycles"
+    }
+]

--- a/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/general_inst.json
+++ b/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/general_inst.json
@@ -1,0 +1,57 @@
+[
+    {
+        "EventName": "INST_RETIRED",
+        "EventCode": "0x00000108",
+        "BriefDescription": "Instruction architecturally executed"
+    },
+    {
+        "EventName": "INST_SPEC",
+        "EventCode": "0x00000208",
+        "BriefDescription": "Instruction speculatively executed"
+    },
+    {
+        "EventName": "DP_SPEC",
+        "EventCode": "0x00000408",
+        "BriefDescription": "Integer data-processing instruction speculatively executed"
+    },
+    {
+        "EventName": "PC_WRITE_SPEC",
+        "EventCode": "0x00000808",
+        "BriefDescription": "PC write instruction speculatively executed"
+    },
+    {
+        "EventName": "CRYPTO_SPEC",
+        "EventCode": "0x00001008",
+        "BriefDescription": "Crypto instruction speculatively executed"
+    },
+    {
+        "EventName": "FENCE.i_SPEC",
+        "EventCode": "0x00002008",
+        "BriefDescription": "FENCE.i speculatively executed"
+    },
+    {
+        "EventName": "OP_RETIRED",
+        "EventCode": "0x00004008",
+        "BriefDescription": "Micro-operation architecturally executed"
+    },
+    {
+        "EventName": "OP_SPEC",
+        "EventCode": "0x00008008",
+        "BriefDescription": "Micro-operation speculatively executed"
+    },
+    {
+        "EventName": "DECODE_MOP",
+        "EventCode": "0x00010008",
+        "BriefDescription": "decode mop"
+    },
+    {
+        "EventName": "TPE_SPEC",
+        "EventCode": "0x00020008",
+        "BriefDescription": "TPE Instruction speculatively executed"
+    },
+    {
+        "EventName": "FUSION_SPEC",
+        "EventCode": "0x00040008",
+        "BriefDescription": "Fusion Instruction speculatively executed"
+    }
+]

--- a/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/l1dcache.json
+++ b/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/l1dcache.json
@@ -1,0 +1,197 @@
+[
+  {
+      "EventName": "L1D_CACHE_REFILL",
+      "EventCode": "0x00000101",
+      "BriefDescription": "L1 data cache refill"
+  },
+  {
+      "EventName": "L1D_CACHE",
+      "EventCode": "0x00000201",
+      "BriefDescription": "L1 data cache access"
+  },
+  {
+      "EventName": "L1D_CACHE_WB",
+      "EventCode": "0x00000401",
+      "BriefDescription": "L1 data cache write-back"
+  },
+  {
+      "EventName": "L1D_CACHE_LMISS_RD",
+      "EventCode": "0x00000801",
+      "BriefDescription": "Level 1 data cache long-latency miss"
+  },
+  {
+      "EventName": "L1D_CACHE_RD",
+      "EventCode": "0x00001001",
+      "BriefDescription": "L1 data cache read"
+  },
+  {
+      "EventName": "L1D_CACHE_WR",
+      "EventCode": "0x00002001",
+      "BriefDescription": "L1 data cache write"
+  },
+  {
+      "EventName": "L1D_CACHE_REFILL_RD",
+      "EventCode": "0x00004001",
+      "BriefDescription": "L1 data cache refill read"
+  },
+  {
+      "EventName": "L1D_CACHE_REFILL_WR",
+      "EventCode": "0x00008001",
+      "BriefDescription": "L1 data cache refill write"
+  },
+  {
+      "EventName": "L1D_CACHE_REFILL_INNER",
+      "EventCode": "0x00010001",
+      "BriefDescription": "L1 data cache refill inner"
+  },
+  {
+      "EventName": "L1D_CACHE_REFILL_OUTER",
+      "EventCode": "0x00020001",
+      "BriefDescription": "L1 data cache refill outer"
+  },
+  {
+      "EventName": "L1D_CACHE_WB_VICTIM",
+      "EventCode": "0x00040001",
+      "BriefDescription": "L1 data cache write-back victim"
+  },
+  {
+      "EventName": "L1D_CACHE_WB_CLEAN",
+      "EventCode": "0x00080001",
+      "BriefDescription": "L1 data cache write-back clean"
+  },
+  {
+      "EventName": "L1D_CACHE_INVAL",
+      "EventCode": "0x00100001",
+      "BriefDescription": "L1 data cache invalidate"
+  },
+  {
+      "EventName": "LDST_L1_PF_REFILL",
+      "EventCode": "0x00200001",
+      "BriefDescription": "L1 refill due to load store prefetch miss"
+  },
+  {
+      "EventName": "LDST_L1_PF_LATE",
+      "EventCode": "0x00400001",
+      "BriefDescription": "Load store hit prefetch"
+  },
+  {
+      "EventName": "L1D_CACHE_REFILL_INER_L2",
+      "EventCode": "0x00800001",
+      "BriefDescription": "L1 data cache refill iner L2"
+  },
+  {
+      "EventName": "L1D_CACHE_REFILL_INER_L3",
+      "EventCode": "0x01000001",
+      "BriefDescription": "L1 data cache refill iner L3"
+  },
+  {
+      "EventName": "L1D_TLB_REFILL_RD_PF",
+      "EventCode": "0x02000001",
+      "BriefDescription": "L1 data TLB refill with read prefetch"
+  },
+  {
+      "EventName": "STORE_STREAM",
+      "EventCode": "0x04000001",
+      "BriefDescription": "store stream"
+  },
+  {
+      "EventName": "LDST_NUKE_RAR",
+      "EventCode": "0x08000001",
+      "BriefDescription": "Load/Store nuke due to read after read"
+  },
+  {
+      "EventName": "LDST_NUKE_RAW",
+      "EventCode": "0x10000001",
+      "BriefDescription": "Load/Store nuke due to read after write"
+  },
+  {
+      "EventName": "LDST_L1_PF_GEN_PAGE",
+      "EventCode": "0x20000001",
+      "BriefDescription": "Load/Store L1 cache pager prefetch"
+  },
+  {
+      "EventName": "LDST_L1_PF_GEN_STRIDE",
+      "EventCode": "0x40000001",
+      "BriefDescription": "Load/Store L1 cahce stride prefetch"
+  },
+  {
+      "EventName": "LDST_L2_PF_GEN_LD",
+      "EventCode": "0x80000001",
+      "BriefDescription": "L2 cache prefetch load"
+  },
+  {
+      "EventName": "LDST_L2_PF_GEN_ST",
+      "EventCode": "0x100000001",
+      "BriefDescription": "L2 cache prefetch store"
+  },
+  {
+      "EventName": "LS_PF_TRAIN_TABLE_ALLOC",
+      "EventCode": "0x200000001",
+      "BriefDescription": "prefetch training table allocation"
+  },
+  {
+      "EventName": "LS_PF_PHT_LOOKUP",
+      "EventCode": "0x400000001",
+      "BriefDescription": "Pattern History Table prefetch lookup"
+  },
+  {
+      "EventName": "LS_PF_PHT_LOOKUP_HIT",
+      "EventCode": "0x800000001",
+      "BriefDescription": "Pattern History Table prefetch lookup hit"
+  },
+  {
+      "EventName": "LS_PF_GEN_TABLE_ALLOC",
+      "EventCode": "0x1000000001",
+      "BriefDescription": "Load/Store Prefetch Generated Page Table Allocation"
+  },
+  {
+      "EventName": "LS_PF_GEN_TABLE_ALLOC_PF_PEND",
+      "EventCode": "0x2000000001",
+      "BriefDescription": "Load/Store Prefetch Generated Page Table Allocation Pending Due to Full Queue"
+  },
+  {
+      "EventName": "LS_PF_PRQ_ALLOC_PF_PEND",
+      "EventCode": "0x4000000001",
+      "BriefDescription": "Load/Store Prefetch Request Queue Allocation Pending Prefetch"
+  },
+  {
+      "EventName": "LDST_L1_PF",
+      "EventCode": "0x8000000001",
+      "BriefDescription": "Load/Store L1 Software Prefetch Count"
+  },
+  {
+      "EventName": "LDST_L1_PF_HIT",
+      "EventCode": "0x10000000001",
+      "BriefDescription": "Load/Store L1 Software Prefetch Hit Count"
+  },
+  {
+      "EventName": "LDST_LRQ_FULL",
+      "EventCode": "0x20000000001",
+      "BriefDescription": "Load/Store Load Request Queue Full Count"
+  },
+  {
+      "EventName": "MAX_POWER_THROTTLE_ACTIVE",
+      "EventCode": "0x80000000001",
+      "BriefDescription": "Maximum Power Throttle Active Event"
+  },
+  {
+      "EventName": "DIDT_THROTTLE_ACTIVE",
+      "EventCode": "0x100000000001",
+      "BriefDescription": "Dynamic Instruction Deferral Throttle Active Event"
+  },
+  {
+      "EventName": "NEAR_CAS",
+      "EventCode": "0x200000000001",
+      "BriefDescription": "Compare-And-Swap Near Address Event Count"
+  },
+  {
+      "EventName": "NEAR_CAS_PASS",
+      "EventCode": "0x400000000001",
+      "BriefDescription": "Compare-And-Swap Near Address Passed Event Count"
+  },
+  {
+      "EventName": "FAR_CAS",
+      "EventCode": "0x800000000001",
+      "BriefDescription": "Compare-And-Swap Far Address Event Count"
+  }
+]

--- a/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/l1icache.json
+++ b/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/l1icache.json
@@ -1,0 +1,97 @@
+[
+    {
+        "EventName": "L1I_CACHE_REFILL",
+        "EventCode": "0x00000102",
+        "BriefDescription": "L1 instruction cache refill"
+    },
+    {
+        "EventName": "L1I_CACHE",
+        "EventCode": "0x00000202",
+        "BriefDescription": "Level 1 instruction cache access"
+    },
+    {
+        "EventName": "L1I_CACHE_LMISS",
+        "EventCode": "0x00000402",
+        "BriefDescription": "L1 instruction cache long latency miss"
+    },
+    {
+        "EventName": "UNUSED_PF",
+        "EventCode": "0x00000802",
+        "BriefDescription": "Unused prefetch data"
+    },
+    {
+        "EventName": "PFT_SENT",
+        "EventCode": "0x00001002",
+        "BriefDescription": "Number of the prefetch target request"
+    },
+    {
+        "EventName": "PFT_USEFUL",
+        "EventCode": "0x00002002",
+        "BriefDescription": "Useful prefetch target"
+    },
+    {
+        "EventName": "PFT_DROP",
+        "EventCode": "0x00004002",
+        "BriefDescription": "drop prefetch target"
+    },
+    {
+        "EventName": "TQ_FULL",
+        "EventCode": "0x00008002",
+        "BriefDescription": "TQ entry is full"
+    },
+    {
+        "EventName": "STASH_DROP",
+        "EventCode": "0x00010002",
+        "BriefDescription": "Drop stash request"
+    },
+    {
+        "EventName": "L1I_CACH_INVAL_ALL",
+        "EventCode": "0x00020002",
+        "BriefDescription": "Level 1 Instruction Cache Invalidate All"
+    },
+    {
+        "EventName": "TXDAT_LCRD_BLOCK",
+        "EventCode": "0x00040002",
+        "BriefDescription": "Transmit Data Link Credit Block"
+    },
+    {
+        "EventName": "TXRSP_LCRD_BLOCK",
+        "EventCode": "0x00080002",
+        "BriefDescription": "Transmit Response Link Credit Block"
+    },
+    {
+        "EventName": "TXREQ_LCRD_BLOCK",
+        "EventCode": "0x00100002",
+        "BriefDescription": "Transmit Request Link Credit Block"
+    },
+    {
+        "EventName": "L1I_CACH_INVAL_ALL_LOCAL",
+        "EventCode": "0x00200002",
+        "BriefDescription": "Level 1 Instruction Cache Invalidate All (Local)"
+    },
+    {
+        "EventName": "L1I_CACH_INVAL_ALL_REMOTE",
+        "EventCode": "0x00400002",
+        "BriefDescription": "Level 1 Instruction Cache Invalidate All (Remote)"
+    },
+    {
+        "EventName": "L1I_CACH_INVAL_VA_LOCAL",
+        "EventCode": "0x00800002",
+        "BriefDescription": "Level 1 Instruction Cache Invalidate Virtual Address (Local)"
+    },
+    {
+        "EventName": "L1I_CACH_INVAL_VA_REMOTE",
+        "EventCode": "0x01000002",
+        "BriefDescription": "Level 1 Instruction Cache Invalidate Virtual Address (Remote)"
+    },
+    {
+        "EventName": "DEADBLOCK",
+        "EventCode": "0x04000002",
+        "BriefDescription": "Dead Block"
+    },
+    {
+        "EventName": "L2_CACHE_HIT_LINE_PF",
+        "EventCode": "0x08000002",
+        "BriefDescription": "Level 2 Cache Hit Line Prefetch"
+    }
+]

--- a/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/l2cache.json
+++ b/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/l2cache.json
@@ -1,0 +1,112 @@
+[
+  {
+      "EventName": "L2_CACHE",
+      "EventCode": "0x00000103",
+      "BriefDescription": "L2 cache access"
+  },
+  {
+      "EventName": "L2_CACHE_REFILL",
+      "EventCode": "0x00000203",
+      "BriefDescription": "L2cache refill"
+  },
+  {
+      "EventName": "L2_CACHE_WB",
+      "EventCode": "0x00000403",
+      "BriefDescription": "L2 cache write-back"
+  },
+  {
+      "EventName": "L2_CACHE_RD",
+      "EventCode": "0x00000803",
+      "BriefDescription": "L2 cache access, read"
+  },
+  {
+      "EventName": "L2_CACHE_WR",
+      "EventCode": "0x00001003",
+      "BriefDescription": "L2 cache access, write"
+  },
+  {
+      "EventName": "L2_CACHE_REFILL_RD",
+      "EventCode": "0x00002003",
+      "BriefDescription": "L2 cache refill, read"
+  },
+  {
+      "EventName": "L2_CACHE_WB_VICTIM",
+      "EventCode": "0x00004003",
+      "BriefDescription": "L2 cache write-back, victim"
+  },
+  {
+      "EventName": "L2_CACHE_WB_CLEAN",
+      "EventCode": "0x00008003",
+      "BriefDescription": "L2 cache write-back, cleaning and coherency"
+  },
+  {
+      "EventName": "L2_CACHE_INVAL",
+      "EventCode": "0x00010003",
+      "BriefDescription": "L2 cache invalidate"
+  },
+  {
+      "EventName": "L2_CACHE_LMISS_RD",
+      "EventCode": "0x00020003",
+      "BriefDescription": "L2 cache long latency miss"
+  },
+  {
+      "EventName": "CACHE_IF_REFILL",
+      "EventCode": "0x00080003",
+      "BriefDescription": "L2 cache refill due to ifu read"
+  },
+  {
+      "EventName": "CACHE_LS_REFILL",
+      "EventCode": "0x00100003",
+      "BriefDescription": "L2 cache refill due to ls read"
+  },
+  {
+      "EventName": "CACHE_TBW_REFILL",
+      "EventCode": "0x00200003",
+      "BriefDescription": "L2 cache refill due to MMU read"
+  },
+  {
+      "EventName": "CACHE_PF_REFILL",
+      "EventCode": "0x00400003",
+      "BriefDescription": "L2 cache refill due to prefetch"
+  },
+  {
+      "EventName": "CACHE_PF_LATE_REFILL",
+      "EventCode": "0x00800003",
+      "BriefDescription": "L2 cache refill due to prefetch late"
+  },
+  {
+      "EventName": "CACHE_PF",
+      "EventCode": "0x01000003",
+      "BriefDescription": "L2 cache prefetch"
+  },
+  {
+      "EventName": "CACHE_PF_HIT",
+      "EventCode": "0x02000003",
+      "BriefDescription": "L2 cache prefetch hit"
+  },
+  {
+      "EventName": "CACHE_INNER_REFILL",
+      "EventCode": "0x04000003",
+      "BriefDescription": "L2 cache refill due to inner read request"
+  },
+  {
+      "EventName": "CACHE_OUTER_REFILL",
+      "EventCode": "0x08000003",
+      "BriefDescription": "L2 cache refill due to outer read request"
+  },
+  {
+      "EventName": "L2_CACHE_ALLOCATE",
+      "EventCode": "0x10000003",
+      "BriefDescription": "L2 cache allocate"
+  },
+  {
+      "EventName": "BUS_ACCESS_TRACE",
+      "EventCode": "0x20000003",
+      "BriefDescription": "Bus access trace request"
+  },
+  {
+      "EventName": "BUS_REQUEST_RETRYNOCRD",
+      "EventCode": "0x40000003",
+      "BriefDescription": "Bus request retrynocrd"
+  }
+]

--- a/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/l3cache.json
+++ b/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/l3cache.json
@@ -1,0 +1,32 @@
+[
+    {
+        "EventName": "L3_CACHE_ALLOCATE",
+        "EventCode": "0x00000104",
+        "BriefDescription": "Attributable L 3 data cache allocation without refill"
+    },
+    {
+        "EventName": "L3_CACHE_REFILL",
+        "EventCode": "0x00000204",
+        "BriefDescription": "Attributable L3 unified cache refill"
+    },
+    {
+        "EventName": "L3_CACHE",
+        "EventCode": "0x00000404",
+        "BriefDescription": "Attributable Level 3 unified cache access"
+    },
+    {
+        "EventName": "LL_CACHE_RD",
+        "EventCode": "0x00000804",
+        "BriefDescription": "Last level cache access, read"
+    },
+    {
+        "EventName": "LL_CACHE_MISS_RD",
+        "EventCode": "0x00001004",
+        "BriefDescription": "Last level cache miss, read"
+    },
+    {
+        "EventName": "L3_CACHE_RD",
+        "EventCode": "0x00002004",
+        "BriefDescription": "L3 cache read"
+    }
+]

--- a/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/ldst.json
+++ b/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/ldst.json
@@ -1,0 +1,67 @@
+[
+    {
+        "EventName": "UNALIGNED_LD_SPEC",
+        "EventCode": "0x00000107",
+        "BriefDescription": "Unaligned load speculation"
+    },
+    {
+        "EventName": "UNALIGNED_ST_SPEC",
+        "EventCode": "0x00000207",
+        "BriefDescription": "Unaligned store speculation"
+    },
+    {
+        "EventName": "UNALIGNED_LDST_SPEC",
+        "EventCode": "0x00000407",
+        "BriefDescription": "Unaligned load/store speculation"
+    },
+    {
+        "EventName": "LD_SPEC",
+        "EventCode": "0x00000807",
+        "BriefDescription": "Load speculation"
+    },
+    {
+        "EventName": "ST_SPEC",
+        "EventCode": "0x00001007",
+        "BriefDescription": "Store speculation"
+    },
+    {
+        "EventName": "SFENCE_SPEC",
+        "EventCode": "0x00002007",
+        "BriefDescription": "SFENCE speculatively executed"
+    },
+    {
+        "EventName": "FENCE_SPEC",
+        "EventCode": "0x00004007",
+        "BriefDescription": "FENCE speculatively executed"
+    },
+    {
+        "EventName": "RC_LD_SPEC",
+        "EventCode": "0x00008007",
+        "BriefDescription": "RC load speculation"
+    },
+    {
+        "EventName": "RC_ST_SPEC",
+        "EventCode": "0x00010007",
+        "BriefDescription": "RC store speculation"
+    },
+    {
+        "EventName": "LR_SPEC",
+        "EventCode": "0x00020007",
+        "BriefDescription": "Load-Reserved speculatively executed"
+    },
+    {
+        "EventName": "SC_PASS_SPEC",
+        "EventCode": "0x00040007",
+        "BriefDescription": "Successful store-condiitional speculatively executed"
+    },
+    {
+        "EventName": "SC_FAlL_SPEC",
+        "EventCode": "0x00080007",
+        "BriefDescription": "Failed store-condiitional speculatively executed"
+    },
+    {
+        "EventName": "SC_SPEC",
+        "EventCode": "0x00100007",
+        "BriefDescription": "Store-condiitional  speculatively executed"
+    }
+]

--- a/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/mem.json
+++ b/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/mem.json
@@ -1,0 +1,182 @@
+[
+  {
+    "EventName": "MEM_ACCESS",
+    "EventCode": "0x00000105",
+    "BriefDescription": "Memory access"
+  },
+  {
+    "EventName": "BUS_ACCESS",
+    "EventCode": "0x00000205",
+    "BriefDescription": "Bus access"
+  },
+  {
+    "EventName": "MEMORY_ERROR",
+    "EventCode": "0x00000405",
+    "BriefDescription": "Memory error"
+  },
+  {
+    "EventName": "REMOTE_ACCESS",
+    "EventCode": "0x00000805",
+    "BriefDescription": "Remote access"
+  },
+  {
+    "EventName": "BUS_ACCESS_RD",
+    "EventCode": "0x00001005",
+    "BriefDescription": "Bus access read"
+  },
+  {
+    "EventName": "BUS_ACCESS_WR",
+    "EventCode": "0x00002005",
+    "BriefDescription": "Bus access write"
+  },
+  {
+    "EventName": "MEM_ACCESS_RD",
+    "EventCode": "0x00004005",
+    "BriefDescription": "Memory access read"
+  },
+  {
+    "EventName": "MEM_ACCESS_WR",
+    "EventCode": "0x00008005",
+    "BriefDescription": "Memory access write"
+  },
+  {
+    "EventName": "LDST_ALIGN_LAT",
+    "EventCode": "0x00010005",
+    "BriefDescription": "Load/store align latency"
+  },
+  {
+    "EventName": "LD_ALIGN_LAT",
+    "EventCode": "0x00020005",
+    "BriefDescription": "Load align latency"
+  },
+  {
+    "EventName": "ST_ALIGN_LAT",
+    "EventCode": "0x00040005",
+    "BriefDescription": "Store align latency"
+  },
+  {
+    "EventName": "BUS_REQUEST_REQ",
+    "EventCode": "0x000400005",
+    "BriefDescription": "CHI Bus Request Sent"
+  },
+  {
+    "EventName": "BUS_REQUEST_RETRY",
+    "EventCode": "0x000800005",
+    "BriefDescription": "CHI Bus Request Retried"
+  },
+  {
+    "EventName": "BUS_REQUEST_SN",
+    "EventCode": "0x001000005",
+    "BriefDescription": "CHI Snoop Request Sent to L2"
+  },
+  {
+    "EventName": "L2TLB_PF_REFILL",
+    "EventCode": "0x002000005",
+    "BriefDescription": "L2 TLB Prefetch-Induced Leaf Page Refill"
+  },
+  {
+    "EventName": "TBW",
+    "EventCode": "0x004000005",
+    "BriefDescription": "Page Table Walk"
+  },
+  {
+    "EventName": "TBW_DESC",
+    "EventCode": "0x008000005",
+    "BriefDescription": "Page Table Walk Descriptor"
+  },
+  {
+    "EventName": "S1L2_HIT",
+    "EventCode": "0x010000005",
+    "BriefDescription": "Stage1 level 2 page table hit"
+  },
+  {
+    "EventName": "S1L1_HIT",
+    "EventCode": "0x020000005",
+    "BriefDescription": "Stage 1 level 1 page table hit"
+  },
+  {
+    "EventName": "S1L0_HIT",
+    "EventCode": "0x040000005",
+    "BriefDescription": "Stage 1 level 0 page table hit"
+  },
+  {
+    "EventName": "S2L2_HIT",
+    "EventCode": "0x080000005",
+    "BriefDescription": "Stage 2 level 2 page table hit"
+  },
+  {
+    "EventName": "IPA_REQ",
+    "EventCode": "0x100000005",
+    "BriefDescription": "Intermediate physical address request"
+  },
+  {
+    "EventName": "IPA_REFILL",
+    "EventCode": "0x200000005",
+    "BriefDescription": "Intermediate physical address refill"
+  },
+  {
+    "EventName": "S1_FLT",
+    "EventCode": "0x400000005",
+    "BriefDescription": "Stage 1 fault"
+  },
+  {
+    "EventName": "S2_FLT",
+    "EventCode": "0x800000005",
+    "BriefDescription": "Stage 2 fault"
+  },
+  {
+    "EventName": "COLT_REFILL",
+    "EventCode": "0x1000000005",
+    "BriefDescription": "Coalescing translation refill"
+  },
+  {
+    "EventName": "PMP_PLT",
+    "EventCode": "0x2000000005",
+    "BriefDescription": "Physical memory protection fault"
+  },
+  {
+    "EventName": "MTT_REQ",
+    "EventCode": "0x4000000005",
+    "BriefDescription": "Memory tracking table request"
+  },
+  {
+    "EventName": "MTT_L3_HIT",
+    "EventCode": "0x8000000005",
+    "BriefDescription": "Memory tracking table  level 3 hit"
+  },
+  {
+    "EventName": "MTT_L2_HIT",
+    "EventCode": "0x10000000005",
+    "BriefDescription": "Memory tracking table level 2 hit"
+  },
+  {
+    "EventName": "MTT_L1_HIT",
+    "EventCode": "0x20000000005",
+    "BriefDescription": "Memory tracking table level 1 hit"
+  },
+  {
+    "EventName": "MTT_LEAFPAGE_HIT",
+    "EventCode": "0x40000000005",
+    "BriefDescription": "Memory tracking table leaf page hit"
+  },
+  {
+    "EventName": "MTT_WLK",
+    "EventCode": "0x80000000005",
+    "BriefDescription": "Memory tracking table walk"
+  },
+  {
+    "EventName": "MTTCACHE_REFILL",
+    "EventCode": "0x100000000005",
+    "BriefDescription": "Memory tracking table cache refill"
+  },
+  {
+    "EventName": "MTT_FLT",
+    "EventCode": "0x200000000005",
+    "BriefDescription": "Memory tracking table fault"
+  },
+  {
+    "EventName": "MTTSIZE_LESS_THAN_PTESIZE",
+    "EventCode": "0x400000000005",
+    "BriefDescription": "Memory tracking table size less than pte size"
+  }
+]

--- a/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/pipeline.json
+++ b/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/pipeline.json
@@ -1,0 +1,132 @@
+[
+    {
+        "EventName": "STALL_FRONTEND",
+        "EventCode": "0x00000106",
+        "BriefDescription": "Frontend stall"
+    },
+    {
+        "EventName": "STALL_BACKEND",
+        "EventCode": "0x00000206",
+        "BriefDescription": "Backend stall"
+    },
+    {
+        "EventName": "STALL",
+        "EventCode": "0x00000406",
+        "BriefDescription": "Stall"
+    },
+    {
+        "EventName": "STALL_SLOT_BACKEND",
+        "EventCode": "0x00000806",
+        "BriefDescription": "Backend stall slot"
+    },
+    {
+        "EventName": "STALL_SLOT_FRONTEND",
+        "EventCode": "0x00001006",
+        "BriefDescription": "Frontend stall slot"
+    },
+    {
+        "EventName": "STALL_SLOT",
+        "EventCode": "0x00002006",
+        "BriefDescription": "Stall slot"
+    },
+    {
+        "EventName": "STALL_BACKEND_MEM",
+        "EventCode": "0x00004006",
+        "BriefDescription": "Backend stall due to memory"
+    },
+    {
+        "EventName": "IDR_STALL_IXU_SCHED",
+        "EventCode": "0x00008006",
+        "BriefDescription": "IXU scheduler stall"
+    },
+    {
+        "EventName": "VX_IQ_STALL",
+        "EventCode": "0x00010006",
+        "BriefDescription": "Dispatch stall due to VX scheduler entries"
+    },
+    {
+        "EventName": "MCQ_FULL_STALL",
+        "EventCode": "0x00020006",
+        "BriefDescription": "Dispatch stall due to MCQ entries"
+    },
+    {
+        "EventName": "STALL_FRONTED_FLUSH",
+        "EventCode": "0x00040006",
+        "BriefDescription": "Dispatch stall due to fronted flush"
+    },
+    {
+        "EventName": "STALL_BACKEND_CACHE",
+        "EventCode": "0x00080006",
+        "BriefDescription": "Dispatch stall due to L1 data cache miss"
+    },
+    {
+        "EventName": "STALL_BACKEND_TLB",
+        "EventCode": "0x00100006",
+        "BriefDescription": "Dispatch stall due to L1 data TLB miss"
+    },
+    {
+        "EventName": "STALL_BACKEND_RESOURCE",
+        "EventCode": "0x00200006",
+        "BriefDescription": "Dispatch stall due to lack of any core resource"
+    },
+    {
+        "EventName": "FSU_ISSUED",
+        "EventCode": "0x00400006",
+        "BriefDescription": "Uops issued by the FSU scheduler"
+    },
+    {
+        "EventName": "IXU_NUM_UOP_ISSUED",
+        "EventCode": "0x00800006",
+        "BriefDescription": "Instructions issued by the IXU scheduler"
+    },
+    {
+        "EventName": "FLAG_DISP_STALL",
+        "EventCode": "0x01000006",
+        "BriefDescription": "Dispatch stall due to mop flag miss"
+    },
+    {
+        "EventName": "GEN_DISP_STALL",
+        "EventCode": "0x02000006",
+        "BriefDescription": "Dispatch stall due to general register miss"
+    },
+    {
+        "EventName": "VEC_DISP_STALL",
+        "EventCode": "0x04000006",
+        "BriefDescription": "Dispatch stall due to vector register miss"
+    },
+    {
+        "EventName": "SX_IQ_STALL",
+        "EventCode": "0x08000006",
+        "BriefDescription": "Stall due to sx issue queue full"
+    },
+    {
+        "EventName": "MX_IQ_STALL",
+        "EventCode": "0x10000006",
+        "BriefDescription": "Stall due to mx issue queue full"
+    },
+    {
+        "EventName": "LS_IQ_STALL",
+        "EventCode": "0x20000006",
+        "BriefDescription": "Stall due to ls queue full"
+    },
+    {
+        "EventName": "STALL_FRONTEND_TLB",
+        "EventCode": "0x80000006",
+        "BriefDescription": "No operation issued due to the frontend TLB"
+    },
+    {
+        "EventName": "STALL_FRONTEND_CACHE",
+        "EventCode": "0x100000006",
+        "BriefDescription": "No operation issued due to the front cache"
+    },
+    {
+        "EventName": "FPG",
+        "EventCode": "0x200000006",
+        "BriefDescription": "Front-End Pipeline Gating"
+    },
+    {
+        "EventName": "VTYPE_FLUSH",
+        "EventCode": "0x400000006",
+        "BriefDescription": "Flush due to fialed prediction of writing vtype csr"
+    }
+]

--- a/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/spe.json
+++ b/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/spe.json
@@ -1,0 +1,7 @@
+[
+    {
+        "EventName": "SAMPLE_POP",
+        "EventCode": "0x0000010d",
+        "BriefDescription": "Sample population"
+    }
+]

--- a/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/tlb.json
+++ b/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/tlb.json
@@ -1,0 +1,82 @@
+[
+    {
+        "EventName": "L1I_TLB_REFILL",
+        "EventCode": "0x00000100",
+        "BriefDescription": "L1 instruction TLB refill"
+    },
+    {
+        "EventName": "L1D_TLB_REFILL",
+        "EventCode": "0x00000200",
+        "BriefDescription": "L1 data TLB refill"
+    },
+    {
+        "EventName": "L1D_TLB",
+        "EventCode": "0x00000800",
+        "BriefDescription": "L1 data TLB access"
+    },
+    {
+        "EventName": "L1I_TLB",
+        "EventCode": "0x00001000",
+        "BriefDescription": "L1 instruction TLB access"
+    },
+    {
+        "EventName": "L2_TLB_REFILL",
+        "EventCode": "0x00002000",
+        "BriefDescription": "Atrributable L2 unified TLB refill"
+    },
+    {
+        "EventName": "L2_TLB",
+        "EventCode": "0x00004000",
+        "BriefDescription": "Attributable L2 unified TLB access"
+    },
+    {
+        "EventName": "DTLB_WALK",
+        "EventCode": "0x00008000",
+        "BriefDescription": "Access to data TLB that caused a translation (or page) table walk"
+    },
+    {
+        "EventName": "ITLB_WALK",
+        "EventCode": "0x00010000",
+        "BriefDescription": "Access to instruction TLB that caused a page table walk"
+    },
+    {
+        "EventName": "L1D_TLB_REFILL_RD",
+        "EventCode": "0x00020000",
+        "BriefDescription": "L1 data TLB refill read"
+    },
+    {
+        "EventName": "L1D_TLB_REFILL_WR",
+        "EventCode": "0x00040000",
+        "BriefDescription": "L1 data TLB refill write"
+    },
+    {
+        "EventName": "L1D_TLB_RD",
+        "EventCode": "0x00080000",
+        "BriefDescription": "L1 data TLB read"
+    },
+    {
+        "EventName": "L1D_TLB_WR",
+        "EventCode": "0x00100000",
+        "BriefDescription": "L1 data TLB write"
+    },
+    {
+        "EventName": "L2_TLB_REFILL_RD",
+        "EventCode": "0x00200000",
+        "BriefDescription": "L2 unified TLB refill, read"
+    },
+    {
+        "EventName": "L2_TLB_REFILL_WR",
+        "EventCode": "0x00400000",
+        "BriefDescription": "L2 unified TLB refill, write"
+    },
+    {
+        "EventName": "L2_TLB_RD",
+        "EventCode": "0x00800000",
+        "BriefDescription": "L2 unified TLB access, read"
+    },
+    {
+        "EventName": "L2_TLB_WR",
+        "EventCode": "0x01000000",
+        "BriefDescription": "L2 unified TLB access, write"
+    }
+]

--- a/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/vec.json
+++ b/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/vec.json
@@ -1,0 +1,82 @@
+[
+    {
+        "EventName": "VFP_SPEC",
+        "EventCode": "0x0000010c",
+        "BriefDescription": "Floating point operation speculatively executed"
+    },
+    {
+        "EventName": "VEC_INST_SPEC",
+        "EventCode": "0x0000020c",
+        "BriefDescription": "Vector instrution speculatively executed"
+    },
+    {
+        "EventName": "FP_HP_SPEC",
+        "EventCode": "0x0000040c",
+        "BriefDescription": "Half-precision floating-point operation speculatively executed"
+    },
+    {
+        "EventName": "FP_SP_SPEC",
+        "EventCode": "0x0000080c",
+        "BriefDescription": "Single-precision floating-point operation speculatively executed"
+    },
+    {
+        "EventName": "FP_DP_SPEC",
+        "EventCode": "0x0000100c",
+        "BriefDescription": "Double-precision floating-point operation speculatively executed"
+    },
+    {
+        "EventName": "VX_MASKED_OP",
+        "EventCode": "0x0000200c",
+        "BriefDescription": "Vector masked operation"
+    },
+    {
+        "EventName": "VX_EMPTY_MASKED_OP",
+        "EventCode": "0x0000400c",
+        "BriefDescription": "Vector mask empty operation"
+    },
+    {
+        "EventName": "VX_FULL_MASKED_OP",
+        "EventCode": "0x0000800c",
+        "BriefDescription": "Vector mask full operation"
+    },
+    {
+        "EventName": "VX_PARTIAL_MASKED_OP",
+        "EventCode": "0x0001000c",
+        "BriefDescription": "Vector mask partial operation"
+    },
+    {
+        "EventName": "VX_NOT_FULL_MASKED_OP",
+        "EventCode": "0x0002000c",
+        "BriefDescription": "Vector mask not full operation"
+    },
+    {
+        "EventName": "FP_VEC_SPEC",
+        "EventCode": "0x010000c",
+        "BriefDescription": "Vector floating-point element operations speculatively executed"
+    },
+    {
+        "EventName": "FP_SCALE_SPEC",
+        "EventCode": "0x020000c",
+        "BriefDescription": "Scalable floating-point element operations speculatively executed"
+    },
+    {
+        "EventName": "VEC_INT08_SPEC",
+        "EventCode": "0x040000c",
+        "BriefDescription": "Operation counted by VEC_INT_SPEC where the largest type is 8-bit integer"
+    },
+    {
+        "EventName": "VEC_INT16_SPEC",
+        "EventCode": "0x080000c",
+        "BriefDescription": "Operation counted by ASE_SVE_INT_SPEC where the largest type is 16-bit integer"
+    },
+    {
+        "EventName": "VEC_INT32_SPEC",
+        "EventCode": "0x100000c",
+        "BriefDescription": "Operation counted by ASE_SVE_INT_SPEC where the largest type is 32-bit integer"
+    },
+    {
+        "EventName": "VEC_INT64_SPEC",
+        "EventCode": "0x200000c",
+        "BriefDescription": "Operation counted by ASE_SVE_INT_SPEC where the largest type is 64-bit integer"
+    }
+]

--- a/tools/perf/pmu-events/arch/riscv/mapfile.csv
+++ b/tools/perf/pmu-events/arch/riscv/mapfile.csv
@@ -17,3 +17,4 @@
 0x489-0x8000000000000007-0x[[:xdigit:]]+,v1,sifive/u74,core
 0x5b7-0x0-0x0,v1,thead/c900-legacy,core
 0x90c010d,v1,thead/th1520-ddr,uncore
+0x0-0x8000000000000920-0x3000020240831,v1,lrw/lrw-core,core


### PR DESCRIPTION
fixed: #102

driver inclusion
category: feature
Link: https://github.com/RVCK-Project/rvck/issues/102

--------------------------------

This patch adds JSON file for lrw core events, establishing a mapping mechanism between standard performance event names and hardware event codes. This allows users to specify monitoring events via semantic names (e.g., L1D_CACHE_REFILL) instead of traditional hardware encodings.