### PR TITLE
Revert "riscv: mm: Clear compilation warning about last_cpupid"

### DIFF
--- a/arch/riscv/include/asm/sparsemem.h
+++ b/arch/riscv/include/asm/sparsemem.h
@@ -5,7 +5,7 @@
 
 #ifdef CONFIG_SPARSEMEM
 #ifdef CONFIG_64BIT
-#define MAX_PHYSMEM_BITS	44
+#define MAX_PHYSMEM_BITS	56
 #else
 #define MAX_PHYSMEM_BITS	32
 #endif /* CONFIG_64BIT */


### PR DESCRIPTION
fixed: #165

mainline inclusion
 mainline-v5.17-rc1
 3270bfdb9e4a01bb15d018612a6354c1837b5f97
 bugfix
 https://github.com/RVCK-Project/rvck/issues/165
    
----------------------------------------------------------------
Revert "riscv: mm: Clear compilation warning about last_cpupid"
    
This reverts commit 8e05b3bc32704be032d497efbe6e454ebd367204.
    
original changelog
    
riscv: Allow to dynamically define VA_BITS
With 4-level page table folding at runtime, we don't know at compile time
the size of the virtual address space so we must set VA_BITS dynamically
so that sparsemem reserves the right amount of memory for struct pages.
    
Signed-off-by: Alexandre Ghiti <alexandre.ghiti@canonical.com>
Signed-off-by: Palmer Dabbelt <palmer@rivosinc.com>
Signed-off-by: bailu <bai.lu5@zte.com.cn>
Signed-off-by: liuqingtao <liu.qingtao2@zte.com.cn>