### PR TITLE
Revert "mm: Modify __find_max_addr for memory hole"

### DIFF
--- a/mm/memblock.c
+++ b/mm/memblock.c
@@ -1733,7 +1733,6 @@ phys_addr_t __init_memblock memblock_end_of_DRAM(void)
 
 static phys_addr_t __init_memblock __find_max_addr(phys_addr_t limit)
 {
-	phys_addr_t phys_ram_base = memblock_start_of_DRAM();
 	phys_addr_t max_addr = PHYS_ADDR_MAX;
 	struct memblock_region *r;
 
@@ -1743,10 +1742,11 @@ static phys_addr_t __init_memblock __find_max_addr(phys_addr_t limit)
 	 * of those regions, max_addr will keep original value PHYS_ADDR_MAX
 	 */
 	for_each_mem_region(r) {
-		if ((r->base + r->size) >= (phys_ram_base + limit)) {
-			max_addr = phys_ram_base + limit;
+		if (limit <= r->size) {
+			max_addr = r->base + limit;
 			break;
 		}
+		limit -= r->size;
 	}
 
 	return max_addr;


### PR DESCRIPTION
fixed: #164

mainline inclusion
from mainline-v3.3-rc1
commit c0ce8fef55896a2813a3d94e1b2d0e6d7fab6228
category bugfix
Link https://github.com/RVCK-Project/rvck/issues/164
    
-----------------------------------------------------
Revert "mm: Modify __find_max_addr for memory hole"
    
This reverts commit d7a7f7a18fe742bab9d791ee8e711a214ea9d984.
    
original changelog
    
memblock: Reimplement memblock_enforce_memory_limit()
using __memblock_remove()With recent updates, the basic memblock
operations are robust enough that there's no reason for
memblock_enfore_memory_limit() to directly manipulate memblock
region arrays.  Reimplement it using __memblock_remove().
    
Signed-off-by: Tejun Heo <tj@kernel.org>
Cc: Benjamin Herrenschmidt <benh@kernel.crashing.org>
Cc: Yinghai Lu <yinghai@kernel.org>
Signed-off-by: bailu <bai.lu5@zte.com.cn>
Signed-off-by: liuqingtao <liu.qingtao2@zte.com.cn>