### PR TITLE
th1520-i2s: Fix kernel panic when reading sysfs registers

### DIFF
--- a/sound/soc/xuantie/th1520-i2s.c
+++ b/sound/soc/xuantie/th1520-i2s.c
@@ -649,15 +649,20 @@ static ssize_t th1520_i2s_show(struct device *dev, struct device_attribute *attr
         u32 value, i;
         struct th1520_i2s_priv *priv = dev_get_drvdata(dev);
 
-        for (i = I2S_IISEN; i <= I2S_DR4; i+=0x4) {
+	for (i = I2S_IISEN; i <= I2S_DR4; i += 0x4) {
 			value = readl(priv->regs + i);
 			printk("i2s reg[0x%x]=0x%x\n", i, value);
         }
 
-        for (i = 0; i <= 0xfc ; i+=0x4) {
+	if (priv->audio_cpr_regmap && !IS_ERR(priv->audio_cpr_regmap)) {
+		for (i = 0; i <= 0xfc; i += 0x4) {
 			regmap_read(priv->audio_cpr_regmap,  i, &value);
 			printk("cpr reg[0x%x]=0x%x\n", i, value);
-        }
+		}
+	} else {
+		/* Skip reading on devices with no CPR regmap */
+		printk("No CPR regmap for %s\n", priv->name);
+	}
 
         return 0;
 }


### PR DESCRIPTION
Fix: https://github.com/RVCK-Project/rvck/issues/175

基于 rvck-olk/OLK-next 分支测试。
验证方法：

- 启动 LPI4A 平台；
- `$ sudo cat /sys/devices/platform/soc/ffe7034000.ap-i2s/th1520_i2s_debug/registers`

打补丁前：
```
[  118.379972][ T1241] i2s reg[0x68]=0x0
[  118.383657][ T1241] i2s reg[0x6c]=0x0
[  118.387347][ T1241] Unable to handle kernel access to user memory without uaccess routines at virtual address 0000000000000204
[  118.398782][ T1241] Oops [#1]
[  118.401759][ T1241] Modules linked in: nft_fib_inet nft_fib_ipv4 nft_fib_ipv6 nft_fib nft_reject_inet nf_reject_ipv4 nf_reject_ipv6 nft_reject nft_ct nft_chain_nk
[  118.439260][ T1241] CPU: 2 PID: 1241 Comm: cat Not tainted 6.6.0-next-1204 #1
[  118.446402][ T1241] Hardware name: Sipeed Lichee Pi 4A (DT)
[  118.451979][ T1241] epc : regmap_read+0x12/0x58
[  118.456527][ T1241]  ra : th1520_i2s_show+0x70/0xb2
[  118.461417][ T1241] epc : ffffffff80a02746 ra : ffffffff80d45f90 sp : ffffffc802653c50
[  118.469335][ T1241]  gp : ffffffff8207fc90 tp : ffffffd905abd700 t0 : 3000000000000000
[  118.477251][ T1241]  t1 : 00000000ffff7fff t2 : 305b676572207332 s0 : ffffffc802653c80
[  118.485171][ T1241]  s1 : 0000000000000000 a0 : 0000000000000000 a1 : 0000000000000000
[  118.493088][ T1241]  a2 : ffffffc802653c84 a3 : 0000000000000010 a4 : 0000000000000000
[  118.501005][ T1241]  a5 : 0000000000000000 a6 : 0000000000000003 a7 : c0000000ffff7fff
[  118.508922][ T1241]  s2 : ffffffd90167a440 s3 : 0000000000000100 s4 : ffffffc802653e18
[  118.516837][ T1241]  s5 : ffffffd9037c2898 s6 : fffffffffffff000 s7 : 000000007ffff000
[  118.524753][ T1241]  s8 : 0000003fbdd1a030 s9 : ffffffc802653df0 s10: 0000000000020000
[  118.532670][ T1241]  s11: 0000003fb5696d60 t3 : ffffffc802653ac0 t4 : ffffffff81e2df00
[  118.540586][ T1241]  t5 : ffffffff8209f2c0 t6 : ffffffc802653ad8
[  118.546593][ T1241] status: 0000000200000120 badaddr: 0000000000000204 cause: 000000000000000d
[  118.555205][ T1241] [<ffffffff80a02746>] regmap_read+0x12/0x58
[  118.561044][ T1241] [<ffffffff80d45f90>] th1520_i2s_show+0x70/0xb2
[  118.567229][ T1241] [<ffffffff809d24e6>] dev_attr_show+0x1a/0x50
[  118.573241][ T1241] [<ffffffff803db26c>] sysfs_kf_seq_show+0x74/0xe2
[  118.579602][ T1241] [<ffffffff803d9a68>] kernfs_seq_show+0x20/0x28
[  118.585784][ T1241] [<ffffffff8035d7f8>] seq_read_iter+0xda/0x36c
[  118.591886][ T1241] [<ffffffff803da884>] kernfs_fop_read_iter+0x3a/0x42
[  118.598503][ T1241] [<ffffffff803284b6>] vfs_read+0x204/0x2aa
[  118.604255][ T1241] [<ffffffff80329156>] ksys_read+0x6a/0xf0
[  118.609919][ T1241] [<ffffffff803291fc>] __riscv_sys_read+0x20/0x28
[  118.616188][ T1241] [<ffffffff81178b2e>] do_trap_ecall_u+0xa8/0x19a
[  118.622467][ T1241] [<ffffffff81186c3c>] ret_from_exception+0x0/0x64
[  118.628845][ T1241] Code: b799 0013 0000 0013 0000 7179 f022 f406 ec26 1800 (2783) 2045 
[  118.637001][ T1241] ---[ end trace 0000000000000000 ]---
[  118.642353][ T1241] th1520-event soc:th1520-event: set rebootmode:0x22
[  118.648905][ T1241] Kernel panic - not syncing: Fatal exception
[  118.654828][ T1241] SMP: stopping secondary CPUs
[  118.659475][ T1241] [panic_cpufreq_notifier_call]Match the clock sw status to the hw after rst
[  118.668248][ T1241] ---[ end Kernel panic - not syncing: Fatal exception ]---
```

打补丁后：
```
[   44.156340][ T1210] i2s reg[0x64]=0x0
[   44.160029][ T1210] i2s reg[0x68]=0x0
[   44.163711][ T1210] i2s reg[0x6c]=0x0
[   44.167397][ T1210] No CPR regmap for ap-i2s                 <========= 正常打印
[   44.177689][ T1211] i2s reg[0x0]=0x0
[   44.181324][ T1211] i2s reg[0x4]=0x0
[   44.184948][ T1211] i2s reg[0x8]=0x0
[   44.188562][ T1211] i2s reg[0xc]=0x0
[   44.192170][ T1211] i2s reg[0x10]=0x0
[   44.195863][ T1211] i2s reg[0x14]=0x0
[   44.199553][ T1211] i2s reg[0x18]=0x0
[   44.203243][ T1211] i2s reg[0x1c]=0x0
[   44.206907][ T1211] i2s reg[0x20]=0x0
[   44.210596][ T1211] i2s reg[0x24]=0x0
[   44.214284][ T1211] i2s reg[0x28]=0x0
[   44.217972][ T1211] i2s reg[0x2c]=0x0
[   44.221668][ T1211] i2s reg[0x30]=0x0
[   44.225375][ T1211] i2s reg[0x34]=0x0
[   44.229087][ T1211] i2s reg[0x38]=0x0
[   44.232783][ T1211] i2s reg[0x3c]=0x0
[   44.236474][ T1211] i2s reg[0x40]=0x0
[   44.240170][ T1211] i2s reg[0x44]=0x0
[   44.243865][ T1211] i2s reg[0x48]=0x0
[   44.247554][ T1211] i2s reg[0x4c]=0x0
[   44.251239][ T1211] i2s reg[0x50]=0x0
[   44.254905][ T1211] i2s reg[0x54]=0x0
[   44.258590][ T1211] i2s reg[0x58]=0x0
[   44.262274][ T1211] i2s reg[0x5c]=0x0
[   44.265956][ T1211] i2s reg[0x60]=0x0
[   44.269642][ T1211] i2s reg[0x64]=0x0
[   44.273325][ T1211] i2s reg[0x68]=0x0
[   44.277010][ T1211] i2s reg[0x6c]=0x0
[   44.280702][ T1211] cpr reg[0x0]=0x1ac00f
[   44.284735][ T1211] cpr reg[0x4]=0x3f2535f
[   44.288858][ T1211] cpr reg[0x8]=0x2000000
[   44.292978][ T1211] cpr reg[0xc]=0x7000
[   44.296844][ T1211] cpr reg[0x10]=0x7fbff1f
[   44.301053][ T1211] cpr reg[0x14]=0x7ffff18
...
```