### PR TITLE
Revert "mango pci hack:broadcast when no MSI source known"

### DIFF
--- a/drivers/pci/pcie/portdrv.c
+++ b/drivers/pci/pcie/portdrv.c
@@ -600,7 +600,7 @@ void pcie_port_service_unregister(struct pcie_port_service_driver *drv)
 }
 
 /* If this switch is set, PCIe port native services should not be enabled. */
-bool pcie_ports_disabled = true;
+bool pcie_ports_disabled;
 
 /*
  * If the user specified "pcie_ports=native", use the PCIe services regardless


### PR DESCRIPTION
fixed: #181

mainline inclusion
category bugfix
from mainline-v6.2-rc1
commit https://github.com/torvalds/linux/commit/a1ccd3d911382f68753033c6adcf69663c2a9fc5
Link:https://github.com/RVCK-Project/rvck/issues/181

-------------------------------------------------
Revert "mango pci hack:broadcast when no MSI source known"

This reverts commit 24fb032c56a4def5a88dae22d16ded4fec44c508.

This merge requires a revert, as disabling the PCIe port native services 
will severely impact the normal operation of the server's PCIe advanced 
features (such as AER/DPC/HP).

original changelog

PCI/portdrv: Squash into portdrv.c
Squash portdrv_core.c and portdrv_pci.c into portdrv.c to make it easier
to find things.  The whole thing is less than 1000 lines, and it's a 
pain to bounce back and forth between two files.

Several portdrv_core.c functions were non-static because they were
referenced from portdrv_pci.c.  Make them static since they're now all 
in portdrv.c.

No functional change intended.

Link: https://lore.kernel.org/r/20221019204127.44463-2-helgaas@kernel.org
Signed-off-by: Bjorn Helgaas <bhelgaas@google.com>
Signed-off-by: Bjorn Helgaas <bhelgaas@google.com>
Reviewed-by: Christoph Hellwig <hch@lst.de>
Reviewed-by: Keith Busch <kbusch@kernel.org>
Signed-off-by: liuqingtao <liu.qingtao2@zte.com.cn>
Signed-off-by: hu.yuye<hu.yuye@zte.com.cn>