### PR TITLE
serial: 8250_core: Remove unneeded ->iotype assignment

### DIFF
--- a/drivers/tty/serial/8250/8250_core.c
+++ b/drivers/tty/serial/8250/8250_core.c
@@ -833,13 +833,11 @@ static int serial8250_platform_probe(struct platform_device *pdev)
 	struct device *dev = &pdev->dev;
 	struct uart_8250_port uart = { 0 };
 	struct resource *regs;
-	unsigned char iotype;
 	int ret, line;
 
 	regs = platform_get_resource(pdev, IORESOURCE_IO, 0);
 	if (regs) {
 		uart.port.iobase = regs->start;
-		iotype = UPIO_PORT;
 	} else {
 		regs = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 		if (!regs) {
@@ -850,7 +848,6 @@ static int serial8250_platform_probe(struct platform_device *pdev)
 		uart.port.mapbase = regs->start;
 		uart.port.mapsize = resource_size(regs);
 		uart.port.flags = UPF_IOREMAP;
-		iotype = UPIO_MEM;
 	}
 
 	/* Default clock frequency*/
@@ -870,12 +867,6 @@ static int serial8250_platform_probe(struct platform_device *pdev)
 		if (!uart.port.membase)
 			return -ENOMEM;
 	}
-
-	/*
-	 * The previous call may not set iotype correctly when reg-io-width
-	 * property is absent and it doesn't support IO port resource.
-	 */
-	uart.port.iotype = iotype;
 
 	line = serial8250_register_8250_port(&uart);
 	if (line < 0)


### PR DESCRIPTION
fixed #186

serial: 8250_core: Remove unneeded ->iotype assignment

mainline inclusion
from mainline-v6.14-rc3
commit 34bbb5d5137f32be3186a995a5ad4c60aaad11a7
category: feature
bugzilla: https://github.com/RVCK-Project/rvck/issues/186

Reference: https://github.com/torvalds/linux/commit/34bbb5d5137f32be3186a995a5ad4c60aaad11a7

--------------------------------

If ->iobase is set the default will be UPIO_PORT for ->iotype after
the uart_read_and_validate_port_properties() call. Hence no need
to assign that explicitly. Otherwise it will be UPIO_MEM.

Signed-off-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
Link: https://lore.kernel.org/r/20250124161530.398361-6-andriy.shevchenko@linux.intel.com
Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
Signed-off-by: Wenhong Liu <liu.wenhong35@zte.com.cn>
Signed-off-by: liuqingtao <liu.qingtao2@zte.com.cn>