### PR TITLE
fix k1 boot failed with mmc error

### DIFF
--- a/arch/riscv/boot/dts/spacemit/k1.dtsi
+++ b/arch/riscv/boot/dts/spacemit/k1.dtsi
@@ -1160,8 +1160,9 @@
 			interrupt-parent = <&intc>;
 			clocks = <&syscon_apmu CLK_SDH_AXI>,
 				 <&syscon_apmu CLK_SDH0>,
+				 <&syscon_apbc CLK_AIB_BUS>,
 				 <&syscon_apmu CLK_AIB>;
-			clock-names = "core", "io", "aib";
+			clock-names = "core", "io", "aib-bus", "aib";
 			resets = <&syscon_apmu RESET_SDH_AXI>,
 				 <&syscon_apmu RESET_SDH0>;
 			reset-names = "core", "io";

--- a/drivers/gpio/gpio-k1.c
+++ b/drivers/gpio/gpio-k1.c
@@ -57,6 +57,9 @@ struct k1_gpio_chip {
 	unsigned int ngpio;
 	unsigned int nbank;
 	struct k1_gpio_bank *banks;
+
+	struct clk *core_clk;
+	struct clk *bus_clk;
 };
 
 static int k1_gpio_to_irq(struct gpio_chip *chip, unsigned int offset)
@@ -301,7 +304,6 @@ static int k1_gpio_probe(struct platform_device *pdev)
 	struct k1_gpio_bank *bank;
 	struct resource *res;
 	struct irq_domain *domain;
-	struct clk *clk;
 
 	int irq, i, ret;
 	void __iomem *base;
@@ -334,15 +336,29 @@ static int k1_gpio_probe(struct platform_device *pdev)
 		return ret;
 	}
 
-	clk = devm_clk_get(dev, NULL);
-	if (IS_ERR(clk)) {
-		dev_err(dev, "Fail to get gpio clock, error %ld.\n",
-			PTR_ERR(clk));
-		return PTR_ERR(clk);
+	k1_chip->core_clk = devm_clk_get(dev, "core");
+	if (IS_ERR(k1_chip->core_clk)) {
+		dev_err(dev, "Fail to get gpio func clock, error %ld.\n",
+			PTR_ERR(k1_chip->core_clk));
+		return PTR_ERR(k1_chip->core_clk);
 	}
-	ret = clk_prepare_enable(clk);
+	ret = clk_prepare_enable(k1_chip->core_clk);
 	if (ret) {
-		dev_err(dev, "Fail to enable gpio clock, error %d.\n", ret);
+		dev_err(dev, "Fail to enable gpio func clock, error %d.\n", ret);
+		return ret;
+	}
+
+	k1_chip->bus_clk = devm_clk_get(dev, "bus");
+	if (IS_ERR(k1_chip->bus_clk)) {
+		dev_err(dev, "Fail to get gpio bus clock, error %ld.\n",
+			PTR_ERR(k1_chip->bus_clk));
+		clk_disable_unprepare(k1_chip->core_clk);
+		return PTR_ERR(k1_chip->bus_clk);
+	}
+	ret = clk_prepare_enable(k1_chip->bus_clk);
+	if (ret) {
+		dev_err(dev, "Fail to enable gpio bus clock, error %d.\n", ret);
+		clk_disable_unprepare(k1_chip->core_clk);
 		return ret;
 	}
 

--- a/drivers/i2c/busses/i2c-spacemit-k1.c
+++ b/drivers/i2c/busses/i2c-spacemit-k1.c
@@ -770,8 +770,6 @@ xfer_retry:
 	spacemit_i2c->xfer_mode = SPACEMIT_I2C_MODE_PIO;
 	timeout = jiffies_to_usecs(spacemit_i2c->timeout);
 
-	if (!spacemit_i2c->clk_always_on)
-		clk_enable(spacemit_i2c->clk);
 	spacemit_i2c_controller_reset(spacemit_i2c);
 	udelay(2);
 
@@ -826,9 +824,6 @@ xfer_retry:
 	}
 
 	spacemit_i2c_disable(spacemit_i2c);
-
-	if (!spacemit_i2c->clk_always_on)
-		clk_disable(spacemit_i2c->clk);
 
 	if (unlikely(timeout <= 0)) {
 		dev_alert(spacemit_i2c->dev, "i2c pio transfer timeout\n");
@@ -895,7 +890,6 @@ static int spacemit_i2c_xfer(struct i2c_adapter *adapt, struct i2c_msg msgs[], i
 	struct spacemit_i2c_dev *spacemit_i2c = i2c_get_adapdata(adapt);
 	int ret = 0, xfer_try = 0;
 	unsigned long time_left;
-	bool clk_directly = false;
 
 	/*
 	 * at the end of system power off sequence, system will send
@@ -917,29 +911,6 @@ static int spacemit_i2c_xfer(struct i2c_adapter *adapt, struct i2c_msg msgs[], i
 	if (spacemit_i2c->shutdown) {
 		mutex_unlock(&spacemit_i2c->mtx);
 		return -ENXIO;
-	}
-
-	if (!spacemit_i2c->clk_always_on) {
-		ret = pm_runtime_get_sync(spacemit_i2c->dev);
-		if (unlikely(ret < 0)) {
-			/*
-			 * during system suspend_late to system resume_early stage,
-			 * if PM runtime is suspended, we will get -EACCES return
-			 * value, so we need to enable clock directly, and disable after
-			 * i2c transfer is finished, if PM runtime is active, it will
-			 * work normally. During this stage, pmic onkey ISR that
-			 * invoked in an irq thread may use i2c interface if we have
-			 * onkey press action
-			 */
-			if (likely(ret == -EACCES)) {
-				clk_directly = true;
-				clk_enable(spacemit_i2c->clk);
-			} else {
-				dev_err(spacemit_i2c->dev, "pm runtime sync error: %d\n",
-					ret);
-				goto err_runtime;
-			}
-		}
 	}
 
 xfer_retry:
@@ -1029,17 +1000,6 @@ timeout_xfex:
 		goto xfer_retry;
 	}
 
-err_runtime:
-	if (unlikely(clk_directly)) {
-		/* if clock is enabled directly, here disable it */
-		clk_disable(spacemit_i2c->clk);
-	}
-
-	if (!spacemit_i2c->clk_always_on) {
-		pm_runtime_mark_last_busy(spacemit_i2c->dev);
-		pm_runtime_put_autosuspend(spacemit_i2c->dev);
-	}
-
 	mutex_unlock(&spacemit_i2c->mtx);
 
 	return ret < 0 ? ret : num;
@@ -1107,9 +1067,6 @@ static int spacemit_i2c_parse_dt(struct platform_device *pdev,
 
 	/* default: interrupt mode */
 	spacemit_i2c->xfer_mode = SPACEMIT_I2C_MODE_INTERRUPT;
-
-	/* true: the clock will always on and not use runtime mechanism */
-	spacemit_i2c->clk_always_on = of_property_read_bool(dnode, "spacemit,clk-always-on");
 
 	/* apb clock: 26MHz or 52MHz */
 	ret = of_property_read_u32(dnode, "spacemit,apb_clock", &spacemit_i2c->apb_clock);
@@ -1184,13 +1141,22 @@ static int spacemit_i2c_probe(struct platform_device *pdev)
 		goto err_out;
 	}
 
-	spacemit_i2c->clk = devm_clk_get(spacemit_i2c->dev, NULL);
-	if (IS_ERR(spacemit_i2c->clk)) {
-		dev_err(spacemit_i2c->dev, "failed to get clock\n");
-		ret = PTR_ERR(spacemit_i2c->clk);
+	spacemit_i2c->func_clk = devm_clk_get(spacemit_i2c->dev, "func");
+	if (IS_ERR(spacemit_i2c->func_clk)) {
+		dev_err(spacemit_i2c->dev, "failed to get func clock\n");
+		ret = PTR_ERR(spacemit_i2c->func_clk);
 		goto err_out;
 	}
-	clk_prepare_enable(spacemit_i2c->clk);
+	clk_prepare_enable(spacemit_i2c->func_clk);
+
+	spacemit_i2c->bus_clk = devm_clk_get(spacemit_i2c->dev, "bus");
+	if (IS_ERR(spacemit_i2c->bus_clk)) {
+		dev_err(spacemit_i2c->dev, "failed to get bus clock\n");
+		clk_disable_unprepare(spacemit_i2c->func_clk);
+		ret = PTR_ERR(spacemit_i2c->bus_clk);
+		goto err_out;
+	}
+	clk_prepare_enable(spacemit_i2c->bus_clk);
 
 	i2c_set_adapdata(&spacemit_i2c->adapt, spacemit_i2c);
 	spacemit_i2c->adapt.owner = THIS_MODULE;
@@ -1212,15 +1178,6 @@ static int spacemit_i2c_probe(struct platform_device *pdev)
 	init_completion(&spacemit_i2c->complete);
 	spin_lock_init(&spacemit_i2c->fifo_lock);
 
-	if (!spacemit_i2c->clk_always_on) {
-		pm_runtime_set_autosuspend_delay(spacemit_i2c->dev, MSEC_PER_SEC);
-		pm_runtime_use_autosuspend(spacemit_i2c->dev);
-		pm_runtime_set_active(spacemit_i2c->dev);
-		pm_suspend_ignore_children(&pdev->dev, 1);
-		pm_runtime_enable(spacemit_i2c->dev);
-	} else
-		dev_dbg(spacemit_i2c->dev, "clock keeps always on\n");
-
 	spacemit_i2c->shutdown = false;
 	ret = i2c_add_numbered_adapter(&spacemit_i2c->adapt);
 	if (ret) {
@@ -1231,11 +1188,8 @@ static int spacemit_i2c_probe(struct platform_device *pdev)
 	return 0;
 
 err_clk:
-	if (!spacemit_i2c->clk_always_on) {
-		pm_runtime_disable(spacemit_i2c->dev);
-		pm_runtime_set_suspended(spacemit_i2c->dev);
-	}
-	clk_disable_unprepare(spacemit_i2c->clk);
+	clk_disable_unprepare(spacemit_i2c->func_clk);
+	clk_disable_unprepare(spacemit_i2c->bus_clk);
 err_out:
 	return ret;
 }
@@ -1244,15 +1198,11 @@ static int spacemit_i2c_remove(struct platform_device *pdev)
 {
 	struct spacemit_i2c_dev *spacemit_i2c = platform_get_drvdata(pdev);
 
-	if (!spacemit_i2c->clk_always_on) {
-		pm_runtime_disable(spacemit_i2c->dev);
-		pm_runtime_set_suspended(spacemit_i2c->dev);
-	}
-
 	i2c_del_adapter(&spacemit_i2c->adapt);
 	mutex_destroy(&spacemit_i2c->mtx);
 	reset_control_assert(spacemit_i2c->resets);
-	clk_disable_unprepare(spacemit_i2c->clk);
+	clk_disable_unprepare(spacemit_i2c->func_clk);
+	clk_disable_unprepare(spacemit_i2c->bus_clk);
 	dev_dbg(spacemit_i2c->dev, "driver removed\n");
 
 	return 0;

--- a/drivers/i2c/busses/i2c-spacemit-k1.h
+++ b/drivers/i2c/busses/i2c-spacemit-k1.h
@@ -171,7 +171,8 @@ struct spacemit_i2c_dev {
 	void __iomem		*mapbase;
 
 	struct reset_control    *resets;
-	struct clk		*clk;
+	struct clk		*func_clk;
+	struct clk		*bus_clk;
 	int			irq;
 	int			clk_freq_in;
 	int			clk_freq_out;

--- a/drivers/mmc/host/sdhci-of-k1.c
+++ b/drivers/mmc/host/sdhci-of-k1.c
@@ -137,6 +137,7 @@ struct sdhci_spacemit {
 	struct clk *clk_core;
 	struct clk *clk_io;
 	struct clk *clk_aib;
+	struct clk *clk_aib_bus;
 	struct reset_control *reset;
 	unsigned char power_mode;
 	struct pinctrl_state *pin;
@@ -1305,7 +1306,7 @@ static int spacemit_sdhci_probe(struct platform_device *pdev)
 
 	pltfm_host = sdhci_priv(host);
 	spacemit = sdhci_pltfm_priv(pltfm_host);
-	spacemit->clk_io = devm_clk_get(dev, "sdh-io");
+	spacemit->clk_io = devm_clk_get(dev, "io");
 	if (IS_ERR(spacemit->clk_io))
 		spacemit->clk_io = devm_clk_get(dev, NULL);
 	if (IS_ERR(spacemit->clk_io)) {
@@ -1316,13 +1317,17 @@ static int spacemit_sdhci_probe(struct platform_device *pdev)
 	pltfm_host->clk = spacemit->clk_io;
 	clk_prepare_enable(spacemit->clk_io);
 
-	spacemit->clk_core = devm_clk_get(dev, "sdh-core");
+	spacemit->clk_core = devm_clk_get(dev, "core");
 	if (!IS_ERR(spacemit->clk_core))
 		clk_prepare_enable(spacemit->clk_core);
 
-	spacemit->clk_aib = devm_clk_get(dev, "aib-clk");
+	spacemit->clk_aib = devm_clk_get(dev, "aib");
 	if (!IS_ERR(spacemit->clk_aib))
 		clk_prepare_enable(spacemit->clk_aib);
+
+	spacemit->clk_aib_bus = devm_clk_get(dev, "aib-bus");
+	if (!IS_ERR(spacemit->clk_aib_bus))
+		clk_prepare_enable(spacemit->clk_aib_bus);
 
 	spacemit->reset = devm_reset_control_array_get_optional_shared(dev);
 	if (IS_ERR(spacemit->reset)) {
@@ -1431,6 +1436,8 @@ err_host_freq:
 err_of_parse:
 	reset_control_assert(spacemit->reset);
 err_rst_get:
+	if (!IS_ERR(spacemit->clk_aib_bus))
+		clk_disable_unprepare(spacemit->clk_aib_bus);
 	if (!IS_ERR(spacemit->clk_aib))
 		clk_disable_unprepare(spacemit->clk_aib);
 	clk_disable_unprepare(spacemit->clk_io);
@@ -1452,6 +1459,8 @@ static void spacemit_sdhci_remove(struct platform_device *pdev)
 	sdhci_remove_host(host, 1);
 
 	reset_control_assert(spacemit->reset);
+	if (!IS_ERR(spacemit->clk_aib_bus))
+		clk_disable_unprepare(spacemit->clk_aib_bus);
 	if (!IS_ERR(spacemit->clk_aib))
 		clk_disable_unprepare(spacemit->clk_aib);
 	clk_disable_unprepare(spacemit->clk_io);

--- a/drivers/pinctrl/pinctrl-spacemit-k1.c
+++ b/drivers/pinctrl/pinctrl-spacemit-k1.c
@@ -225,6 +225,10 @@ struct pcs_device {
 	struct pinctrl_desc desc;
 	unsigned int (*read)(void __iomem *reg);
 	void (*write)(unsigned int val, void __iomem *reg);
+
+	struct clk *func_clk;
+	struct clk *bus_clk;
+	struct reset_control *reset;
 };
 
 static int pcs_pinconf_get(struct pinctrl_dev *pctldev, unsigned int pin,
@@ -1753,27 +1757,6 @@ static int pcs_irq_init_chained_handler(struct pcs_device *pcs, struct device_no
 	return 0;
 }
 
-#ifdef CONFIG_PM_SLEEP
-static struct pcs_device *pinctrl_pcs;
-
-static int pinctrl_syscore_suspend(void)
-{
-	pinctrl_force_sleep(pinctrl_pcs->pctl);
-
-	return 0;
-}
-
-static void pinctrl_syscore_resume(void)
-{
-	pinctrl_force_default(pinctrl_pcs->pctl);
-}
-
-static struct syscore_ops pinctrl_syscore_ops = {
-	.suspend = pinctrl_syscore_suspend,
-	.resume = pinctrl_syscore_resume,
-};
-#endif
-
 /**
  * pcs_quirk_missing_pinctrl_cells - handle legacy binding
  * @pcs: pinctrl driver instance
@@ -1822,9 +1805,6 @@ static int pcs_quirk_missing_pinctrl_cells(struct pcs_device *pcs,
 	return error;
 }
 
-static struct clk *psc_clk;
-static struct reset_control *psc_rst;
-
 static int pcs_probe(struct platform_device *pdev)
 {
 	int ret;
@@ -1840,36 +1820,49 @@ static int pcs_probe(struct platform_device *pdev)
 	if (WARN_ON(!soc))
 		return -EINVAL;
 
-	psc_rst = devm_reset_control_get_exclusive(&pdev->dev, "aib_rst");
-	if (IS_ERR(psc_rst)) {
-		ret = PTR_ERR(psc_rst);
+	pcs = devm_kzalloc(&pdev->dev, sizeof(*pcs), GFP_KERNEL);
+	if (!pcs)
+		return -ENOMEM;
+
+	pcs->reset = devm_reset_control_get_exclusive(&pdev->dev, "aib_rst");
+	if (IS_ERR(pcs->reset)) {
+		ret = PTR_ERR(pcs->reset);
 		dev_err(&pdev->dev, "Failed to get reset: %d\n", ret);
 		return -EINVAL;
 	}
 
+	pcs->func_clk = devm_clk_get(&pdev->dev, "func");
+	if (IS_ERR(pcs->func_clk)) {
+		dev_err(&pdev->dev, "Fail to get pinctrl func clock, error %ld.\n",
+			PTR_ERR(pcs->func_clk));
+		return PTR_ERR(pcs->func_clk);
+	}
+
+	pcs->bus_clk = devm_clk_get(&pdev->dev, "bus");
+	if (IS_ERR(pcs->bus_clk)) {
+		dev_err(&pdev->dev, "Fail to get pinctrl bus clock, error %ld.\n",
+			PTR_ERR(pcs->bus_clk));
+		return PTR_ERR(pcs->bus_clk);
+	}
+
 	/* deasser clk  */
-	ret = reset_control_deassert(psc_rst);
+	ret = reset_control_deassert(pcs->reset);
 	if (ret) {
 		dev_err(&pdev->dev, "Failed to deassert reset: %d\n", ret);
 		return -EINVAL;
 	}
 
-	psc_clk = devm_clk_get(&pdev->dev, NULL);
-	if (IS_ERR(psc_clk)) {
-		dev_err(&pdev->dev, "Fail to get pinctrl clock, error %ld.\n",
-			PTR_ERR(psc_clk));
-		return PTR_ERR(psc_clk);
-	}
-
-	ret = clk_prepare_enable(psc_clk);
+	ret = clk_prepare_enable(pcs->func_clk);
 	if (ret) {
-		dev_err(&pdev->dev, "Fail to enable pinctrl clock, error %d.\n", ret);
+		dev_err(&pdev->dev, "Fail to enable pinctrl func clock, error %d.\n", ret);
 		return ret;
 	}
 
-	pcs = devm_kzalloc(&pdev->dev, sizeof(*pcs), GFP_KERNEL);
-	if (!pcs)
-		return -ENOMEM;
+	ret = clk_prepare_enable(pcs->bus_clk);
+	if (ret) {
+		dev_err(&pdev->dev, "Fail to enable pinctrl bus clock, error %d.\n", ret);
+		return ret;
+	}
 
 	pcs->dev = &pdev->dev;
 	pcs->np = np;
@@ -2037,11 +2030,6 @@ static int pcs_probe(struct platform_device *pdev)
 	dev_pm_set_wake_irq(&pdev->dev, pcs->socdata.irq);
 	device_init_wakeup(&pdev->dev, true);
 
-#ifdef CONFIG_PM_SLEEP
-	pinctrl_pcs = pcs;
-	register_syscore_ops(&pinctrl_syscore_ops);
-#endif
-
 	ret = pinctrl_enable(pcs->pctl);
 	if (ret)
 		goto free;
@@ -2060,9 +2048,11 @@ static int pcs_remove(struct platform_device *pdev)
 	if (!pcs)
 		return 0;
 
+	clk_disable_unprepare(pcs->func_clk);
+	clk_disable_unprepare(pcs->bus_clk);
+	reset_control_assert(pcs->reset);
+
 	pcs_free_resources(pcs);
-	clk_disable_unprepare(psc_clk);
-	reset_control_assert(psc_rst);
 
 	return 0;
 }


### PR DESCRIPTION
fix: https://github.com/RVCK-Project/rvck/issues/194

pinctrl/gpio/i2c/mmc drivers are mismatched with the mainline clock driver.

修复后，TF卡工作正常：
~ # [    2.491447] mmc0: new ultra high speed SDR104 SDHC card at address aaaa
[    2.499132] mmcblk0: mmc0:aaaa SD32G 29.7 GiB
[    2.509728]  mmcblk0: p1 p2 p3 p4 p5 p6
TF卡拔出：
[    5.921080] mmc0: card aaaa removed
TF卡插入：
[    8.656955] mmc0: new ultra high speed SDR104 SDHC card at address aaaa
[    8.664443] mmcblk0: mmc0:aaaa SD32G 29.7 GiB
[    8.674911]  mmcblk0: p1 p2 p3 p4 p5 p6
查看mmc块设备：
~ # ls /dev/mmcblk[   12.644963] platform th1520-wdt: deferred probe pending
*
/dev/mmcblk0       /dev/mmcblk0p5     /dev/mmcblk2p1     /dev/mmcblk2p6
/dev/mmcblk0p1     /dev/mmcblk0p6     /dev/mmcblk2p2     /dev/mmcblk2rpmb
/dev/mmcblk0p2     /dev/mmcblk2       /dev/mmcblk2p3
/dev/mmcblk0p3     /dev/mmcblk2boot0  /dev/mmcblk2p4
/dev/mmcblk0p4     /dev/mmcblk2boot1  /dev/mmcblk2p5
~ # 
尝试mount分区：
~ # mount /dev/mmcblk0p6 /mnt/
[   26.272260] EXT4-fs (mmcblk0p6): recovery complete
[   26.277256] EXT4-fs (mmcblk0p6): mounted filesystem 34b4e9b0-2752-4c6e-a744-5bd2a909407c r/w with ordered data mode. Quota mode: none.
~ # 
~ # ls /mnt/
bin         init        linuxrc     opt         sbin        tmp.sh
busybox     lib         lost+found  proc        sys         usr
dev         lib64       media       root        tmp         var
etc         libexec     mnt         run         tmp.log
~ # 
~ # [   33.894506] ldo5: disabling