### PR TITLE
Revert "riscv:uprobe: fix flush_icache to ensure that instructions are refreshed when switching to user mode"

### DIFF
--- a/arch/riscv/kernel/probes/uprobes.c
+++ b/arch/riscv/kernel/probes/uprobes.c
@@ -177,6 +177,6 @@ void arch_uprobe_copy_ixol(struct page *page, unsigned long vaddr,
 		*(uprobe_opcode_t *)dst = __BUG_INSN_32;
 	}
 
-	flush_icache_range(kaddr, kaddr + len);
+	flush_icache_range(start, start + len);
 	kunmap_atomic(kaddr);
 }


### PR DESCRIPTION
This patch will cause a compilation error, and the original implementation is already aligned with the upstream, so no modification is needed.

fixed: #211