### PR TITLE
fix system hang when bootup on spacemit k3

### DIFF
--- a/drivers/clk/spacemit/ccu-k3.c
+++ b/drivers/clk/spacemit/ccu-k3.c
@@ -983,7 +983,7 @@ static const struct clk_parent_data rcpu_clk_parents[] = {
 	CCU_PARENT_HW(pll1_d6_409p6),
 };
 CCU_MUX_DIV_GATE_FC_DEFINE(rcpu_clk, rcpu_clk_parents, APMU_RCPU_CLK_RES_CTRL,
-			   4, 3, BIT(15), 7, 3, BIT(12), 0);
+			   4, 3, BIT(15), 7, 3, BIT(12), CLK_IS_CRITICAL);
 
 static const struct clk_parent_data dsi4ln2_dsi_esc_parents[] = {
 	CCU_PARENT_HW(pll1_d48_51p2_ap),
@@ -1145,7 +1145,7 @@ CCU_MUX_DIV_GATE_DEFINE(isim_vclk_out3, isim_vclk_parents, APMU_SNR_ISIM_VCLK_CT
 /* APMU clocks end */
 
 /* DCIU clocks start */
-CCU_GATE_DEFINE(hdma_clk, CCU_PARENT_HW(axi_clk), DCIU_DMASYS_CLK_EN, BIT(0), 0);
+CCU_GATE_DEFINE(hdma_clk, CCU_PARENT_HW(axi_clk), DCIU_DMASYS_CLK_EN, BIT(0), CLK_IS_CRITICAL);
 CCU_GATE_DEFINE(dma350_clk, CCU_PARENT_HW(axi_clk), DCIU_DMASYS_SDMA_CLK_EN, BIT(0), 0);
 CCU_GATE_DEFINE(c2_tcm_pipe_clk, CCU_PARENT_HW(axi_clk), DCIU_C2_TCM_PIPE_CLK, BIT(0), 0);
 CCU_GATE_DEFINE(c3_tcm_pipe_clk, CCU_PARENT_HW(axi_clk), DCIU_C3_TCM_PIPE_CLK, BIT(0), 0);


### PR DESCRIPTION
fixed: #212

目前high speed dma 和 rcpu remote core驱动没有加载，但是rcpu会在后台运行，需要保持clk常开。
hdma的clock和CCI的某些模块有关，hdma的clock必须保持常开，系统才能正常工作。

验证方法：
cat arch/riscv/configs/k3_defconfig >> arch/riscv/configs/defconfig
make ARCH=riscv defconfig
make ARCH=riscv CROSS_COMPILE=riscv64-unknown-linux-gnu- -j$(nproc)
替换内核后，尝试引导systemd，能正常启动：

[  OK  ] Reached target Network is Online.
[  OK  ] Reached target Socket Units.
[  OK  ] Started Emergency Shell.
[  OK  ] Reached target Emergency Mode.
         Starting Crash recovery kernel arming...
         Starting Create Volatile Files and Directories...
[FAILED] Failed to start Crash recovery kernel arming.
See 'systemctl status kdump.service' for details.
[  OK  ] Finished Create Volatile Files and Directories.
         Starting RPC Bind...
         Starting Record System Boot/Shutdown in UTMP...
[  OK  ] Finished Record System Boot/Shutdown in UTMP.
         Starting Record Runlevel Change in UTMP...
[  OK  ] Started RPC Bind.
[  OK  ] Finished Record Runlevel Change in UTMP.
You are in emergency mode. After logging in, type "journalctl -xb" to view
system logs, "systemGive root password for maintenance
(or press Control-D to continue): 
