### PR TITLE
perf vendor events riscv: fix lrw core PMU event mapping

### DIFF
--- a/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/branch.json
+++ b/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/branch.json
@@ -50,21 +50,6 @@
         "BriefDescription": "Fetch queue empty"
     },
     {
-        "EventName": "FETCH_MCACHE_INVALIDATE",
-        "EventCode": "0x00040009",
-        "BriefDescription": "Fetch mopcache invalidate"
-    },
-    {
-        "EventName": "FETCH_MCACHE_ICACHE_SWITCH",
-        "EventCode": "0x00080009",
-        "BriefDescription": "Fetch mopcache instruction cache switch"
-    },
-    {
-        "EventName": "FETCH_MCACHE_ICACHE_SWITCH_PENALTY",
-        "EventCode": "0x00100009",
-        "BriefDescription": "Fetch mopcache instruction cache switch penalty"
-    },
-    {
         "EventName": "BR_PRED_BTB_RGN_UPDATE_NREADY",
         "EventCode": "0x00200009",
         "BriefDescription": "Branch prediction branch target buffer region update not ready"

--- a/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/general_cpu.json
+++ b/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/general_cpu.json
@@ -1,10 +1,5 @@
 [
     {
-        "EventName": "CID_WRITE_RETIRED",
-        "EventCode": "0x0000020b",
-        "BriefDescription": "CONTEXTIDR register write"
-    },
-    {
         "EventName": "CPU_CYCLES",
         "EventCode": "0x0000040b",
         "BriefDescription": "cycles"

--- a/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/l3cache.json
+++ b/tools/perf/pmu-events/arch/riscv/lrw/lrw-core/l3cache.json
@@ -1,32 +1,32 @@
 [
     {
-        "EventName": "L3_CACHE_ALLOCATE",
-        "EventCode": "0x00000104",
-        "BriefDescription": "Attributable L 3 data cache allocation without refill"
-    },
-    {
-        "EventName": "L3_CACHE_REFILL",
-        "EventCode": "0x00000204",
-        "BriefDescription": "Attributable L3 unified cache refill"
-    },
-    {
-        "EventName": "L3_CACHE",
-        "EventCode": "0x00000404",
-        "BriefDescription": "Attributable Level 3 unified cache access"
-    },
-    {
-        "EventName": "LL_CACHE_RD",
-        "EventCode": "0x00000804",
-        "BriefDescription": "Last level cache access, read"
-    },
-    {
         "EventName": "LL_CACHE_MISS_RD",
-        "EventCode": "0x00001004",
+        "EventCode": "0x00000104",
         "BriefDescription": "Last level cache miss, read"
     },
     {
+        "EventName": "LL_CACHE_RD",
+        "EventCode": "0x00000204",
+        "BriefDescription": "Last level cache access, read"
+    },
+    {
+        "EventName": "L3_CACHE_REFILL",
+        "EventCode": "0x00000404",
+        "BriefDescription": "Attributable L3 unified cache refill"
+    },
+    {
         "EventName": "L3_CACHE_RD",
-        "EventCode": "0x00002004",
+        "EventCode": "0x00000804",
         "BriefDescription": "L3 cache read"
+    },
+    {
+        "EventName": "L3_CACHE_ALLOCATE",
+        "EventCode": "0x00001004",
+        "BriefDescription": "Attributable L3 data cache allocation without refill"
+    },
+    {
+        "EventName": "L3_CACHE",
+        "EventCode": "0x00002004",
+        "BriefDescription": "Attributable Level 3 unified cache access"
     }
 ]


### PR DESCRIPTION
fixed: #216

driver inclusion
category: bugfix
Link: https://github.com/RVCK-Project/rvck/issues/216

--------------------------------

The lrw core PMU event definitions contained incorrect and unsupported
mappings, which caused perf to expose events that either did not work
or did not correspond to the hardware behavior.

- Removing unsupported events
- Correcting event names and codes
- Ensuring EventName, EventCode, and BriefDescription are consistent
  with the lrw core PMU specification

This fix improves the accuracy of perf event reporting on lrw core.

Signed-off-by: shenlin <shen.lin1@zte.com.cn>
Signed-off-by: liuqingtao <liu.qingtao2@zte.com.cn>