### PR TITLE
riscv: k1: add device tree

### DIFF
--- a/arch/riscv/boot/dts/spacemit/Makefile
+++ b/arch/riscv/boot/dts/spacemit/Makefile
@@ -1,5 +1,6 @@
 dtb-$(CONFIG_SOC_SPACEMIT_K1) += k1-bananapi-f3.dtb
 dtb-$(CONFIG_SOC_SPACEMIT_K1) += k1-muse-pi-pro.dtb
+dtb-$(CONFIG_SOC_SPACEMIT_K1) += k1-muse-pi.dtb
 dtb-$(CONFIG_SOC_SPACEMIT_K3) += k3-pico.dtb
 dtb-$(CONFIG_SOC_SPACEMIT_K3) += k3-com260.dtb
 obj-$(CONFIG_BUILTIN_DTB) += $(addsuffix .o, $(dtb-y))

--- a/arch/riscv/boot/dts/spacemit/Makefile
+++ b/arch/riscv/boot/dts/spacemit/Makefile
@@ -2,6 +2,7 @@ dtb-$(CONFIG_SOC_SPACEMIT_K1) += k1-bananapi-f3.dtb
 dtb-$(CONFIG_SOC_SPACEMIT_K1) += k1-muse-pi-pro.dtb
 dtb-$(CONFIG_SOC_SPACEMIT_K1) += k1-muse-pi.dtb
 dtb-$(CONFIG_SOC_SPACEMIT_K1) += k1-milkv-jupiter.dtb
+dtb-$(CONFIG_SOC_SPACEMIT_K1) += x1-orange-pi-rv2.dtb
 dtb-$(CONFIG_SOC_SPACEMIT_K3) += k3-pico.dtb
 dtb-$(CONFIG_SOC_SPACEMIT_K3) += k3-com260.dtb
 obj-$(CONFIG_BUILTIN_DTB) += $(addsuffix .o, $(dtb-y))

--- a/arch/riscv/boot/dts/spacemit/Makefile
+++ b/arch/riscv/boot/dts/spacemit/Makefile
@@ -1,4 +1,5 @@
 dtb-$(CONFIG_SOC_SPACEMIT_K1) += k1-bananapi-f3.dtb
+dtb-$(CONFIG_SOC_SPACEMIT_K1) += k1-muse-pi-pro.dtb
 dtb-$(CONFIG_SOC_SPACEMIT_K3) += k3-pico.dtb
 dtb-$(CONFIG_SOC_SPACEMIT_K3) += k3-com260.dtb
 obj-$(CONFIG_BUILTIN_DTB) += $(addsuffix .o, $(dtb-y))

--- a/arch/riscv/boot/dts/spacemit/Makefile
+++ b/arch/riscv/boot/dts/spacemit/Makefile
@@ -1,6 +1,7 @@
 dtb-$(CONFIG_SOC_SPACEMIT_K1) += k1-bananapi-f3.dtb
 dtb-$(CONFIG_SOC_SPACEMIT_K1) += k1-muse-pi-pro.dtb
 dtb-$(CONFIG_SOC_SPACEMIT_K1) += k1-muse-pi.dtb
+dtb-$(CONFIG_SOC_SPACEMIT_K1) += k1-milkv-jupiter.dtb
 dtb-$(CONFIG_SOC_SPACEMIT_K3) += k3-pico.dtb
 dtb-$(CONFIG_SOC_SPACEMIT_K3) += k3-com260.dtb
 obj-$(CONFIG_BUILTIN_DTB) += $(addsuffix .o, $(dtb-y))

--- a/arch/riscv/boot/dts/spacemit/k1-milkv-jupiter.dts
+++ b/arch/riscv/boot/dts/spacemit/k1-milkv-jupiter.dts
@@ -1,0 +1,523 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/* Copyright (c) 2023 Spacemit, Inc */
+
+/dts-v1/;
+
+#include "k1.dtsi"
+#include "k1_pinctrl.dtsi"
+
+/ {
+	model = "Milk-V Jupiter";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x00000000 0x0 0x80000000>;
+	};
+
+	memory@100000000 {
+		device_type = "memory";
+		reg = <0x1 0x00000000 0x0 0x80000000>;
+	};
+
+	chosen {
+		bootargs = "earlycon=sbi console=ttyS0,115200n8 loglevel=8 rdinit=/init";
+		stdout-path = "serial0:115200n8";
+	};
+
+	dc_12v: dc-12v {
+		compatible = "regulator-fixed";
+		regulator-name = "dc_12v";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <12000000>;
+		regulator-max-microvolt = <12000000>;
+	};
+
+	vcc4v0_baseboard: vcc4v0-baseboard {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc4v0_baseboard";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <4000000>;
+		regulator-max-microvolt = <4000000>;
+		vin-supply = <&dc_12v>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led1 {
+			label = "pwr-led";
+			gpios = <&gpio 96 0>;
+			default-state = "on";
+			status = "okay";
+		};
+
+		led2 {
+			label = "ssd-led";
+			gpios = <&gpio 92 0>;
+			linux,default-trigger = "disk-activity";
+			status = "okay";
+		};
+	};
+};
+
+&pinctrl {
+	pinctrl-single,gpio-range = <
+		&range GPIO_49  2 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_3V_DS4)
+		&range GPIO_58  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_63  2 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_65  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_67  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_3V_DS4)
+		&range PRI_TDI  2 (MUX_MODE1 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range PRI_TCK  1 (MUX_MODE1 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range PRI_TDO  1 (MUX_MODE1 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_74  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_80  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_3V_DS4)
+		&range GPIO_81  3 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_90  1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_91  2 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range DVL0     1 (MUX_MODE1 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range DVL1     1 (MUX_MODE1 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS0)
+		&range GPIO_110 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_111 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_113 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_114 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_115 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_116 1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_118 1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_123 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS0)
+		&range GPIO_124 1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_125 3 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+	>;
+};
+
+&gpio{
+	gpio-ranges = <
+		&pinctrl 49  GPIO_49  2
+		&pinctrl 58  GPIO_58  1
+		&pinctrl 63  GPIO_63  3
+		&pinctrl 67  GPIO_67  1
+		&pinctrl 70  PRI_TDI  4
+		&pinctrl 74  GPIO_74  1
+		&pinctrl 80  GPIO_80  4
+		&pinctrl 90  GPIO_90  3
+		&pinctrl 96  DVL0     2
+		&pinctrl 110 GPIO_110 1
+		&pinctrl 111 GPIO_111 1
+		&pinctrl 113 GPIO_113 1
+		&pinctrl 114 GPIO_114 3
+		&pinctrl 118 GPIO_118 1
+		&pinctrl 123 GPIO_123 5
+	>;
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart0_2>;
+	status = "okay";
+};
+
+&uart2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart2>;
+	status = "okay";
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_i2c0>;
+	spacemit,i2c-fast-mode;
+	status = "okay";
+};
+
+&i2c1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_i2c1>;
+	spacemit,i2c-fast-mode;
+	status = "okay";
+};
+
+&i2c8 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_i2c8>;
+	status = "okay";
+
+	spmp1@41 {
+		compatible = "spacemit,p1";
+		reg = <0x41>;
+		interrupt-parent = <&intc>;
+		interrupts = <64>;
+		status = "okay";
+
+		regulators {
+			compatible = "spacemit,p1,regulator";
+
+			/* buck */
+			dcdc_1: DCDC_REG1 {
+				regulator-name = "dcdc1";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3450000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <650000>;
+				};
+			};
+
+			dcdc_2: DCDC_REG2 {
+				regulator-name = "dcdc2";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3450000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+			};
+
+			dcdc_3: DCDC_REG3 {
+				regulator-name = "dcdc3";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <1800000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+			};
+
+			dcdc_4: DCDC_REG4 {
+				regulator-name = "dcdc4";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <3300000>;
+				};
+			};
+
+			dcdc_5: DCDC_REG5 {
+				regulator-name = "dcdc5";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3450000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+			};
+
+			dcdc_6: DCDC_REG6 {
+				regulator-name = "dcdc6";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3450000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+			};
+
+			/* aldo */
+			ldo_1: LDO_REG1 {
+				regulator-name = "ldo1";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+				regulator-boot-on;
+
+				/* set the min voltage means will disable this vol in suspend for ldo */
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_2: LDO_REG2 {
+				regulator-name = "ldo2";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_3: LDO_REG3 {
+				regulator-name = "ldo3";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_4: LDO_REG4 {
+				regulator-name = "ldo4";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			/* dldo */
+			ldo_5: LDO_REG5 {
+				regulator-name = "ldo5";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+				regulator-boot-on;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_6: LDO_REG6 {
+				regulator-name = "ldo6";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_7: LDO_REG7 {
+				regulator-name = "ldo7";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_8: LDO_REG8 {
+				regulator-name = "ldo8";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+				regulator-always-on;
+			};
+
+			ldo_9: LDO_REG9 {
+				regulator-name = "ldo9";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+			};
+
+			ldo_10: LDO_REG10 {
+				regulator-name = "ldo10";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+				regulator-always-on;
+			};
+
+			ldo_11: LDO_REG11 {
+				regulator-name = "ldo11";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+			};
+
+			sw_1: SWITCH_REG1 {
+				regulator-name = "switch1";
+			};
+		};
+
+		pmic_pinctrl: pinctrl {
+			compatible = "spacemit,p1,pinctrl";
+			gpio-controller;
+			#gpio-cells = <2>;
+			spm_pmic,npins = <6>;
+		};
+
+		pwr_key: key {
+			compatible = "spacemit,p1,pwrkey";
+		};
+
+		ext_rtc: rtc {
+			compatible = "spacemit,p1,rtc";
+		};
+
+		ext_adc: adc {
+			compatible = "spacemit,p1,adc";
+		};
+	};
+};
+
+/* SD */
+&sdhci0 {
+	pinctrl-names = "default","fast";
+	pinctrl-0 = <&pinctrl_mmc1>;
+	pinctrl-1 = <&pinctrl_mmc1_fast>;
+	bus-width = <4>;
+	cd-gpios = <&gpio 80 0>;
+	cd-inverted;
+	vmmc-supply = <&dcdc_4>;
+	vqmmc-supply = <&ldo_1>;
+	no-mmc;
+	no-sdio;
+	spacemit,sdh-host-caps-disable = <(
+			MMC_CAP_UHS_SDR12 |
+			MMC_CAP_UHS_SDR25
+			)>;
+	spacemit,sdh-quirks = <(
+			SDHCI_QUIRK_BROKEN_CARD_DETECTION |
+			SDHCI_QUIRK_INVERTED_WRITE_PROTECT |
+			SDHCI_QUIRK_BROKEN_TIMEOUT_VAL
+			)>;
+	spacemit,sdh-quirks2 = <(
+			SDHCI_QUIRK2_PRESET_VALUE_BROKEN |
+			SDHCI_QUIRK2_BROKEN_PHY_MODULE |
+			SDHCI_QUIRK2_SET_AIB_MMC
+			)>;
+	spacemit,aib_mmc1_io_reg = <0xD401E81C>;
+	spacemit,apbc_asfar_reg = <0xD4015050>;
+	spacemit,apbc_assar_reg = <0xD4015054>;
+	spacemit,rx_dline_reg = <0x0>;
+	spacemit,tx_dline_reg = <0x0>;
+	spacemit,tx_delaycode = <0x7f>;
+	spacemit,rx_tuning_limit = <50>;
+	spacemit,sdh-freq = <204800000>;
+	status = "okay";
+};
+
+/* SDIO */
+&sdhci1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_mmc2>;
+	bus-width = <4>;
+	non-removable;
+	vqmmc-supply = <&dcdc_3>;
+	no-mmc;
+	no-sd;
+	keep-power-in-suspend;
+	/* bcmdhd use private oob solution rather than dat1/standard wakeup */
+	/delete-property/ enable-sdio-wakeup;
+	spacemit,sdh-host-caps-disable = <(
+			MMC_CAP_UHS_DDR50 |
+			MMC_CAP_NEEDS_POLL
+			)>;
+	spacemit,sdh-quirks = <(
+			SDHCI_QUIRK_BROKEN_CARD_DETECTION |
+			SDHCI_QUIRK_BROKEN_TIMEOUT_VAL
+			)>;
+	spacemit,sdh-quirks2 = <(
+			SDHCI_QUIRK2_PRESET_VALUE_BROKEN |
+			SDHCI_QUIRK2_BROKEN_PHY_MODULE
+			)>;
+	spacemit,rx_dline_reg = <0x0>;
+	spacemit,tx_delaycode = <0xa8 0x78>;
+	spacemit,rx_tuning_limit = <50>;
+	spacemit,sdh-freq = <375000000>;
+	status = "okay";
+};
+
+/* eMMC */
+&sdhci2 {
+	bus-width = <8>;
+	non-removable;
+	mmc-hs400-1_8v;
+	mmc-hs400-enhanced-strobe;
+	no-sd;
+	no-sdio;
+	spacemit,sdh-quirks = <(
+			SDHCI_QUIRK_BROKEN_CARD_DETECTION |
+			SDHCI_QUIRK_BROKEN_TIMEOUT_VAL
+			)>;
+	spacemit,sdh-quirks2 = <(
+			SDHCI_QUIRK2_PRESET_VALUE_BROKEN
+			)>;
+	spacemit,sdh-freq = <375000000>;
+	status = "okay";
+};
+
+&eth0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_gmac0>;
+
+	emac,reset-gpio = <&gpio 110 0>;
+	emac,reset-active-low;
+	emac,reset-delays-us = <0 10000 100000>;
+
+	tx-threshold = <1518>;
+	rx-threshold = <12>;
+	tx-ring-num = <1024>;
+	rx-ring-num = <1024>;
+	dma-burst-len = <5>;
+
+	ref-clock-from-phy;
+
+	clk-tuning-enable;
+	clk-tuning-by-delayline;
+	tx-phase = <60>;
+	rx-phase = <73>;
+
+	phy-handle = <&rgmii0>;
+
+	status = "okay";
+
+	mdio-bus {
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+		rgmii0: phy@0 {
+			compatible = "ethernet-phy-id001c.c916";
+			device_type = "ethernet-phy";
+			reg = <0x1>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&eth1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_gmac1>;
+
+	emac,reset-gpio = <&gpio 115 0>;
+	emac,reset-active-low;
+	emac,reset-delays-us = <0 10000 100000>;
+
+	tx-threshold = <1518>;
+	rx-threshold = <12>;
+	tx-ring-num = <1024>;
+	rx-ring-num = <1024>;
+	dma-burst-len = <5>;
+
+	ref-clock-from-phy;
+
+	clk-tuning-enable;
+	clk-tuning-by-delayline;
+	tx-phase = <90>;
+	rx-phase = <73>;
+
+	phy-handle = <&rgmii1>;
+
+	status = "okay";
+
+	mdio-bus {
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+		rgmii1: phy@1 {
+			compatible = "ethernet-phy-id001c.c916";
+			device_type = "ethernet-phy";
+			reg = <0x1>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&qspi {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_qspi>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <26500000>;
+		m25p,fast-read;
+		broken-flash-reset;
+		status = "okay";
+	};
+};

--- a/arch/riscv/boot/dts/spacemit/k1-muse-pi-pro.dts
+++ b/arch/riscv/boot/dts/spacemit/k1-muse-pi-pro.dts
@@ -1,0 +1,520 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/* Copyright (c) 2023 Spacemit, Inc */
+
+/dts-v1/;
+
+#include "k1.dtsi"
+#include "k1_pinctrl.dtsi"
+
+/ {
+	model = "SpacemiT MUSE Pi Pro";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x00000000 0x0 0x80000000>;
+	};
+
+	memory@100000000 {
+		device_type = "memory";
+		reg = <0x1 0x00000000 0x0 0x80000000>;
+	};
+
+	chosen {
+		bootargs = "earlycon=sbi console=ttyS0,115200n8 loglevel=8 rdinit=/init";
+		stdout-path = "serial0:115200n8";
+	};
+
+	dc_12v: dc-12v {
+		compatible = "regulator-fixed";
+		regulator-name = "dc_12v";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <12000000>;
+		regulator-max-microvolt = <12000000>;
+	};
+
+	vcc4v0_baseboard: vcc4v0-baseboard {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc4v0_baseboard";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <4000000>;
+		regulator-max-microvolt = <4000000>;
+		vin-supply = <&dc_12v>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led1 {
+			label = "sys-led";
+			gpios = <&gpio 96 0>;
+			linux,default-trigger = "none";
+			default-state = "on";
+			status = "okay";
+		};
+	};
+};
+
+
+&pinctrl {
+	pinctrl-single,gpio-range = <
+		&range GPIO_49  2 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_3V_DS4)
+		&range GPIO_58  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_63  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_64  1 (MUX_MODE1 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_65  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_67  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_3V_DS4)
+		&range PRI_TDI  2 (MUX_MODE1 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range PRI_TCK  1 (MUX_MODE1 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range PRI_TDO  1 (MUX_MODE1 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_74  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_79  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_80  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_3V_DS4)
+		&range GPIO_81  3 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_90  1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_91  2 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range DVL0     1 (MUX_MODE1 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range DVL1     1 (MUX_MODE1 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS0)
+		&range GPIO_110 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_111 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_113 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_114 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_115 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_116 1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_118 1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_123 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS0)
+		&range GPIO_124 1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_125 3 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+	>;
+};
+
+&gpio{
+	gpio-ranges = <
+		&pinctrl 49  GPIO_49  2
+		&pinctrl 58  GPIO_58  1
+		&pinctrl 63  GPIO_63  1
+		&pinctrl 65  GPIO_65  1
+		&pinctrl 67  GPIO_67  1
+		&pinctrl 70  PRI_TDI  4
+		&pinctrl 74  GPIO_74  1
+		&pinctrl 79  GPIO_79  1
+		&pinctrl 80  GPIO_80  4
+		&pinctrl 90  GPIO_90  3
+		&pinctrl 96  DVL0     2
+		&pinctrl 110 GPIO_110 1
+		&pinctrl 111 GPIO_111 1
+		&pinctrl 113 GPIO_113 1
+		&pinctrl 114 GPIO_114 3
+		&pinctrl 118 GPIO_118 1
+		&pinctrl 123 GPIO_123 5
+	>;
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart0_2>;
+	status = "okay";
+};
+
+&uart2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart2>;
+	status = "okay";
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_i2c0>;
+	spacemit,i2c-fast-mode;
+	status = "okay";
+};
+
+&i2c1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_i2c1>;
+	spacemit,i2c-fast-mode;
+	status = "okay";
+};
+
+&i2c4 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_i2c4_0>;
+	status = "okay";
+};
+
+&i2c8 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_i2c8>;
+	status = "okay";
+
+	spmp1@41 {
+		compatible = "spacemit,p1";
+		reg = <0x41>;
+		interrupt-parent = <&intc>;
+		interrupts = <64>;
+		status = "okay";
+
+		regulators {
+			compatible = "spacemit,p1,regulator";
+
+			/* buck */
+			dcdc_1: DCDC_REG1 {
+				regulator-name = "dcdc1";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3450000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <650000>;
+				};
+			};
+
+			dcdc_2: DCDC_REG2 {
+				regulator-name = "dcdc2";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3450000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+			};
+
+			dcdc_3: DCDC_REG3 {
+				regulator-name = "dcdc3";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <1800000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+			};
+
+			dcdc_4: DCDC_REG4 {
+				regulator-name = "dcdc4";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <3300000>;
+				};
+			};
+
+			dcdc_5: DCDC_REG5 {
+				regulator-name = "dcdc5";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3450000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+			};
+
+			dcdc_6: DCDC_REG6 {
+				regulator-name = "dcdc6";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3450000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+			};
+
+			/* aldo */
+			ldo_1: LDO_REG1 {
+				regulator-name = "ldo1";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+				regulator-boot-on;
+
+				/* set the min voltage means will disable this vol in suspend for ldo */
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_2: LDO_REG2 {
+				regulator-name = "ldo2";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_3: LDO_REG3 {
+				regulator-name = "ldo3";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_4: LDO_REG4 {
+				regulator-name = "ldo4";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			/* dldo */
+			ldo_5: LDO_REG5 {
+				regulator-name = "ldo5";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+				regulator-boot-on;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_6: LDO_REG6 {
+				regulator-name = "ldo6";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_7: LDO_REG7 {
+				regulator-name = "ldo7";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_8: LDO_REG8 {
+				regulator-name = "ldo8";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+				regulator-always-on;
+			};
+
+			ldo_9: LDO_REG9 {
+				regulator-name = "ldo9";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+			};
+
+			ldo_10: LDO_REG10 {
+				regulator-name = "ldo10";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+				regulator-always-on;
+			};
+
+			ldo_11: LDO_REG11 {
+				regulator-name = "ldo11";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+			};
+
+			sw_1: SWITCH_REG1 {
+				regulator-name = "switch1";
+			};
+		};
+
+		pmic_pinctrl: pinctrl {
+			compatible = "spacemit,p1,pinctrl";
+			gpio-controller;
+			#gpio-cells = <2>;
+			spm_pmic,npins = <6>;
+		};
+
+		pwr_key: key {
+			compatible = "spacemit,p1,pwrkey";
+		};
+
+		ext_rtc: rtc {
+			compatible = "spacemit,p1,rtc";
+		};
+
+		ext_adc: adc {
+			compatible = "spacemit,p1,adc";
+		};
+	};
+};
+
+
+/* SD */
+&sdhci0 {
+	pinctrl-names = "default","fast";
+	pinctrl-0 = <&pinctrl_mmc1>;
+	pinctrl-1 = <&pinctrl_mmc1_fast>;
+	bus-width = <4>;
+	cd-gpios = <&gpio 80 0>;
+	vmmc-supply = <&dcdc_4>;
+	vqmmc-supply = <&ldo_1>;
+	no-mmc;
+	no-sdio;
+	spacemit,sdh-host-caps-disable = <(
+			MMC_CAP_UHS_SDR12 |
+			MMC_CAP_UHS_SDR25
+			)>;
+	spacemit,sdh-quirks = <(
+			SDHCI_QUIRK_BROKEN_CARD_DETECTION |
+			SDHCI_QUIRK_INVERTED_WRITE_PROTECT |
+			SDHCI_QUIRK_BROKEN_TIMEOUT_VAL
+			)>;
+	spacemit,sdh-quirks2 = <(
+			SDHCI_QUIRK2_PRESET_VALUE_BROKEN |
+			SDHCI_QUIRK2_BROKEN_PHY_MODULE |
+			SDHCI_QUIRK2_SET_AIB_MMC
+			)>;
+	spacemit,aib_mmc1_io_reg = <0xD401E81C>;
+	spacemit,apbc_asfar_reg = <0xD4015050>;
+	spacemit,apbc_assar_reg = <0xD4015054>;
+	spacemit,rx_dline_reg = <0x0>;
+	spacemit,tx_dline_reg = <0x0>;
+	spacemit,tx_delaycode = <0x9f>;
+	spacemit,rx_tuning_limit = <50>;
+	spacemit,sdh-freq = <204800000>;
+	status = "okay";
+};
+
+/* SDIO */
+&sdhci1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_mmc2>;
+	bus-width = <4>;
+	non-removable;
+	vqmmc-supply = <&dcdc_3>;
+	no-mmc;
+	no-sd;
+	keep-power-in-suspend;
+	/* bcmdhd use private oob solution rather than dat1/standard wakeup */
+	/delete-property/ enable-sdio-wakeup;
+	spacemit,sdh-host-caps-disable = <(
+			MMC_CAP_UHS_DDR50 |
+			MMC_CAP_NEEDS_POLL
+			)>;
+	spacemit,sdh-quirks = <(
+			SDHCI_QUIRK_BROKEN_CARD_DETECTION |
+			SDHCI_QUIRK_BROKEN_TIMEOUT_VAL
+			)>;
+	spacemit,sdh-quirks2 = <(
+			SDHCI_QUIRK2_PRESET_VALUE_BROKEN |
+			SDHCI_QUIRK2_BROKEN_PHY_MODULE
+			)>;
+	spacemit,rx_dline_reg = <0x0>;
+	spacemit,tx_delaycode = <0xa8 0x78>;
+	spacemit,rx_tuning_limit = <50>;
+	spacemit,sdh-freq = <375000000>;
+	status = "okay";
+};
+
+/* eMMC */
+&sdhci2 {
+	bus-width = <8>;
+	non-removable;
+	mmc-hs400-1_8v;
+	mmc-hs400-enhanced-strobe;
+	no-sd;
+	no-sdio;
+	spacemit,sdh-quirks = <(
+			SDHCI_QUIRK_BROKEN_CARD_DETECTION |
+			SDHCI_QUIRK_BROKEN_TIMEOUT_VAL
+			)>;
+	spacemit,sdh-quirks2 = <(
+			SDHCI_QUIRK2_PRESET_VALUE_BROKEN
+			)>;
+	spacemit,sdh-freq = <375000000>;
+	status = "okay";
+};
+
+&eth0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_gmac0>;
+
+	emac,reset-gpio = <&gpio 110 0>;
+	emac,reset-active-low;
+	emac,reset-delays-us = <0 10000 100000>;
+
+	/* store forward mode */
+	tx-threshold = <1518>;
+	rx-threshold = <12>;
+	tx-ring-num = <1024>;
+	rx-ring-num = <1024>;
+	dma-burst-len = <5>;
+
+	ref-clock-from-phy;
+
+	clk-tuning-enable;
+	clk-tuning-by-delayline;
+	tx-phase = <60>;
+	rx-phase = <73>;
+
+	phy-handle = <&rgmii0>;
+
+	status = "okay";
+
+	mdio-bus {
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+		rgmii0: phy@0 {
+			compatible = "ethernet-phy-id001c.c916";
+			device_type = "ethernet-phy";
+			reg = <0x1>;
+			phy-mode = "rgmii";
+
+			leds {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				lan0-led1@1 {
+					reg = <1>;
+					linux,default-trigger = "netdev";
+				};
+
+				lan0-led2@2 {
+					reg = <2>;
+					linux,default-trigger = "netdev";
+				};
+			};
+		};
+	};
+};
+
+&qspi {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_qspi>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <26500000>;
+		m25p,fast-read;
+		broken-flash-reset;
+		status = "okay";
+	};
+};
+
+&spi3 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_ssp3_0>;
+	status = "okay";
+	k1,spi-clock-rate = <25600000>;
+};
+
+&pwm4 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_pwm4_1>;
+	status = "disable";
+};

--- a/arch/riscv/boot/dts/spacemit/k1-muse-pi.dts
+++ b/arch/riscv/boot/dts/spacemit/k1-muse-pi.dts
@@ -1,0 +1,532 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/* Copyright (c) 2023 Spacemit, Inc */
+
+/dts-v1/;
+
+#include "k1.dtsi"
+#include "k1_pinctrl.dtsi"
+
+/ {
+	model = "SpacemiT MUSE Pi Pro";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x00000000 0x0 0x80000000>;
+	};
+
+	memory@100000000 {
+		device_type = "memory";
+		reg = <0x1 0x00000000 0x0 0x80000000>;
+	};
+
+	chosen {
+		bootargs = "earlycon=sbi console=ttyS0,115200n8 loglevel=8 rdinit=/init";
+		stdout-path = "serial0:115200n8";
+	};
+
+	dc_12v: dc-12v {
+		compatible = "regulator-fixed";
+		regulator-name = "dc_12v";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <12000000>;
+		regulator-max-microvolt = <12000000>;
+	};
+
+	vcc4v0_baseboard: vcc4v0-baseboard {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc4v0_baseboard";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <4000000>;
+		regulator-max-microvolt = <4000000>;
+		vin-supply = <&dc_12v>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led1 {
+			label = "sys-led";
+			gpios = <&gpio 96 0>;
+			linux,default-trigger = "heartbeat";
+			default-state = "on";
+			status = "okay";
+		};
+	};
+};
+
+&pinctrl {
+	pinctrl-single,gpio-range = <
+		&range GPIO_49  2 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_3V_DS4)
+		&range GPIO_58  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_63  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_64  1 (MUX_MODE1 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_65  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_67  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_3V_DS4)
+		&range PRI_TDI  2 (MUX_MODE1 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range PRI_TCK  1 (MUX_MODE1 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range PRI_TDO  1 (MUX_MODE1 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_74  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_79  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_80  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_3V_DS4)
+		&range GPIO_81  3 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_90  1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_91  2 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range DVL0     1 (MUX_MODE1 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range DVL1     1 (MUX_MODE1 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS0)
+		&range GPIO_110 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_111 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_113 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_114 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_115 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_116 1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_118 1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_123 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS0)
+		&range GPIO_124 1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_125 3 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+	>;
+};
+
+&gpio{
+	gpio-ranges = <
+		&pinctrl 49  GPIO_49  2
+		&pinctrl 58  GPIO_58  1
+		&pinctrl 63  GPIO_63  1
+		&pinctrl 65  GPIO_65  1
+		&pinctrl 67  GPIO_67  1
+		&pinctrl 70  PRI_TDI  4
+		&pinctrl 74  GPIO_74  1
+		&pinctrl 79  GPIO_79  1
+		&pinctrl 80  GPIO_80  4
+		&pinctrl 90  GPIO_90  3
+		&pinctrl 96  DVL0     2
+		&pinctrl 110 GPIO_110 1
+		&pinctrl 111 GPIO_111 1
+		&pinctrl 113 GPIO_113 1
+		&pinctrl 114 GPIO_114 3
+		&pinctrl 118 GPIO_118 1
+		&pinctrl 123 GPIO_123 5
+	>;
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart0_2>;
+	status = "okay";
+};
+
+&uart2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart2>;
+	status = "okay";
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_i2c0>;
+	spacemit,i2c-fast-mode;
+	status = "okay";
+};
+
+&i2c1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_i2c1>;
+	spacemit,i2c-fast-mode;
+	status = "okay";
+};
+
+&i2c4 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_i2c4_2>;
+	status = "okay";
+};
+
+&i2c8 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_i2c8>;
+	status = "okay";
+
+	spmp1@41 {
+		compatible = "spacemit,p1";
+		reg = <0x41>;
+		interrupt-parent = <&intc>;
+		interrupts = <64>;
+		status = "okay";
+
+		regulators {
+			compatible = "spacemit,p1,regulator";
+
+			/* buck */
+			dcdc_1: DCDC_REG1 {
+				regulator-name = "dcdc1";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3450000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <650000>;
+				};
+			};
+
+			dcdc_2: DCDC_REG2 {
+				regulator-name = "dcdc2";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3450000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+			};
+
+			dcdc_3: DCDC_REG3 {
+				regulator-name = "dcdc3";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <1800000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+			};
+
+			dcdc_4: DCDC_REG4 {
+				regulator-name = "dcdc4";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <3300000>;
+				};
+			};
+
+			dcdc_5: DCDC_REG5 {
+				regulator-name = "dcdc5";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3450000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+			};
+
+			dcdc_6: DCDC_REG6 {
+				regulator-name = "dcdc6";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3450000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+			};
+
+			/* aldo */
+			ldo_1: LDO_REG1 {
+				regulator-name = "ldo1";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+				regulator-boot-on;
+
+				/* set the min voltage means will disable this vol in suspend for ldo */
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_2: LDO_REG2 {
+				regulator-name = "ldo2";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_3: LDO_REG3 {
+				regulator-name = "ldo3";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_4: LDO_REG4 {
+				regulator-name = "ldo4";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			/* dldo */
+			ldo_5: LDO_REG5 {
+				regulator-name = "ldo5";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+				regulator-boot-on;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_6: LDO_REG6 {
+				regulator-name = "ldo6";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_7: LDO_REG7 {
+				regulator-name = "ldo7";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_8: LDO_REG8 {
+				regulator-name = "ldo8";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+				regulator-always-on;
+			};
+
+			ldo_9: LDO_REG9 {
+				regulator-name = "ldo9";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+			};
+
+			ldo_10: LDO_REG10 {
+				regulator-name = "ldo10";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+				regulator-always-on;
+			};
+
+			ldo_11: LDO_REG11 {
+				regulator-name = "ldo11";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+			};
+
+			sw_1: SWITCH_REG1 {
+				regulator-name = "switch1";
+			};
+		};
+
+		pmic_pinctrl: pinctrl {
+			compatible = "spacemit,p1,pinctrl";
+			gpio-controller;
+			#gpio-cells = <2>;
+			spm_pmic,npins = <6>;
+		};
+
+		pwr_key: key {
+			compatible = "spacemit,p1,pwrkey";
+		};
+
+		ext_rtc: rtc {
+			compatible = "spacemit,p1,rtc";
+		};
+
+		ext_adc: adc {
+			compatible = "spacemit,p1,adc";
+		};
+	};
+};
+
+/* SD */
+&sdhci0 {
+	pinctrl-names = "default","fast";
+	pinctrl-0 = <&pinctrl_mmc1>;
+	pinctrl-1 = <&pinctrl_mmc1_fast>;
+	bus-width = <4>;
+	cd-gpios = <&gpio 80 0>;
+	vmmc-supply = <&dcdc_4>;
+	vqmmc-supply = <&ldo_1>;
+	no-mmc;
+	no-sdio;
+	spacemit,sdh-host-caps-disable = <(
+			MMC_CAP_UHS_SDR12 |
+			MMC_CAP_UHS_SDR25
+			)>;
+	spacemit,sdh-quirks = <(
+			SDHCI_QUIRK_BROKEN_CARD_DETECTION |
+			SDHCI_QUIRK_INVERTED_WRITE_PROTECT |
+			SDHCI_QUIRK_BROKEN_TIMEOUT_VAL
+			)>;
+	spacemit,sdh-quirks2 = <(
+			SDHCI_QUIRK2_PRESET_VALUE_BROKEN |
+			SDHCI_QUIRK2_BROKEN_PHY_MODULE |
+			SDHCI_QUIRK2_SET_AIB_MMC
+			)>;
+	spacemit,aib_mmc1_io_reg = <0xD401E81C>;
+	spacemit,apbc_asfar_reg = <0xD4015050>;
+	spacemit,apbc_assar_reg = <0xD4015054>;
+	spacemit,rx_dline_reg = <0x0>;
+	spacemit,tx_dline_reg = <0x0>;
+	spacemit,tx_delaycode = <0x9f>;
+	spacemit,rx_tuning_limit = <50>;
+	spacemit,sdh-freq = <204800000>;
+	status = "okay";
+};
+
+/* SDIO */
+&sdhci1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_mmc2>;
+	bus-width = <4>;
+	non-removable;
+	vqmmc-supply = <&dcdc_3>;
+	no-mmc;
+	no-sd;
+	keep-power-in-suspend;
+	/* bcmdhd use private oob solution rather than dat1/standard wakeup */
+	/delete-property/ enable-sdio-wakeup;
+	spacemit,sdh-host-caps-disable = <(
+			MMC_CAP_UHS_DDR50 |
+			MMC_CAP_NEEDS_POLL
+			)>;
+	spacemit,sdh-quirks = <(
+			SDHCI_QUIRK_BROKEN_CARD_DETECTION |
+			SDHCI_QUIRK_BROKEN_TIMEOUT_VAL
+			)>;
+	spacemit,sdh-quirks2 = <(
+			SDHCI_QUIRK2_PRESET_VALUE_BROKEN |
+			SDHCI_QUIRK2_BROKEN_PHY_MODULE
+			)>;
+	spacemit,rx_dline_reg = <0x0>;
+	spacemit,tx_delaycode = <0x8f 0x5f>;
+	spacemit,rx_tuning_limit = <50>;
+	spacemit,sdh-freq = <375000000>;
+	status = "okay";
+};
+
+/* eMMC */
+&sdhci2 {
+	bus-width = <8>;
+	non-removable;
+	mmc-hs400-1_8v;
+	mmc-hs400-enhanced-strobe;
+	no-sd;
+	no-sdio;
+	spacemit,sdh-quirks = <(
+			SDHCI_QUIRK_BROKEN_CARD_DETECTION |
+			SDHCI_QUIRK_BROKEN_TIMEOUT_VAL
+			)>;
+	spacemit,sdh-quirks2 = <(
+			SDHCI_QUIRK2_PRESET_VALUE_BROKEN
+			)>;
+	spacemit,sdh-freq = <375000000>;
+	status = "okay";
+};
+
+&eth0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_gmac0>;
+
+	emac,reset-gpio = <&gpio 110 0>;
+	emac,reset-active-low;
+	emac,reset-delays-us = <0 10000 100000>;
+
+	tx-threshold = <1518>;
+	rx-threshold = <12>;
+	tx-ring-num = <1024>;
+	rx-ring-num = <1024>;
+	dma-burst-len = <5>;
+
+	ref-clock-from-phy;
+
+	clk-tuning-enable;
+	clk-tuning-by-delayline;
+	tx-phase = <60>;
+	rx-phase = <73>;
+
+	phy-handle = <&rgmii0>;
+
+	status = "okay";
+
+	mdio-bus {
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+		rgmii0: phy@0 {
+			compatible = "ethernet-phy-id001c.c916";
+			device_type = "ethernet-phy";
+			reg = <0x1>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&eth1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_gmac1>;
+
+	emac,reset-gpio = <&gpio 115 0>;
+	emac,reset-active-low;
+	emac,reset-delays-us = <0 10000 100000>;
+
+	tx-threshold = <1518>;
+	rx-threshold = <12>;
+	tx-ring-num = <1024>;
+	rx-ring-num = <1024>;
+	dma-burst-len = <5>;
+
+	ref-clock-from-phy;
+	clk-tuning-enable;
+	clk-tuning-by-delayline;
+	tx-phase = <90>;
+	rx-phase = <73>;
+
+	phy-handle = <&rgmii1>;
+	status = "okay";
+
+	mdio-bus {
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+		rgmii1: phy@1 {
+			compatible = "ethernet-phy-id001c.c916";
+			device_type = "ethernet-phy";
+			reg = <0x1>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&qspi {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_qspi>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <26500000>;
+		m25p,fast-read;
+		broken-flash-reset;
+		status = "okay";
+	};
+};
+
+&spi3 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_ssp3_0>;
+	k1x,ssp-disable-dma;
+	status = "okay";
+	k1,spi-clock-rate = <25600000>;
+};

--- a/arch/riscv/boot/dts/spacemit/k1-orange-pi-rv2.dts
+++ b/arch/riscv/boot/dts/spacemit/k1-orange-pi-rv2.dts
@@ -1,0 +1,531 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/* Copyright (c) 2023 Spacemit, Inc */
+
+/dts-v1/;
+
+#include "k1.dtsi"
+#include "k1_pinctrl.dtsi"
+
+/ {
+	model = "OrangePi RV2";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x00000000 0x0 0x80000000>;
+	};
+
+	memory@100000000 {
+		device_type = "memory";
+		reg = <0x1 0x00000000 0x0 0x80000000>;
+	};
+
+	chosen {
+		bootargs = "earlycon=sbi console=ttyS0,115200n8 loglevel=8 rdinit=/init";
+		stdout-path = "serial0:115200n8";
+	};
+
+	dc_12v: dc-12v {
+		compatible = "regulator-fixed";
+		regulator-name = "dc_12v";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <12000000>;
+		regulator-max-microvolt = <12000000>;
+	};
+
+	vcc4v0_baseboard: vcc4v0-baseboard {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc4v0_baseboard";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <4000000>;
+		regulator-max-microvolt = <4000000>;
+		vin-supply = <&dc_12v>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led1 {
+			label = "sys-led";
+			gpios = <&gpio 96 0>;
+			linux,default-trigger = "heartbeat";
+			default-state = "on";
+			status = "okay";
+		};
+	};
+
+	ap6256_wifi: ap6256_wifi {
+		compatible = "android,bcmdhd_wlan";
+		gpio_wl_reg_on = <&gpio 67 0>;
+	};
+};
+
+&pinctrl {
+	pinctrl-single,gpio-range = <
+		&range GPIO_49  2 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_3V_DS4)
+		&range GPIO_58  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_63  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_64  1 (MUX_MODE1 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_65  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_67  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_3V_DS4)
+		&range PRI_TDI  2 (MUX_MODE1 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range PRI_TCK  1 (MUX_MODE1 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range PRI_TDO  1 (MUX_MODE1 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		/*&range GPIO_74  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2) */
+		&range GPIO_79  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_80  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_3V_DS4)
+		&range GPIO_81  3 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_90  1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_91  2 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range DVL0     1 (MUX_MODE1 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range DVL1     1 (MUX_MODE1 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS0)
+		&range GPIO_110 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_111 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_113 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_114 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_115 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_116 1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_118 1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_123 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS0)
+		&range GPIO_124 1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_125 3 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+	>;
+};
+
+&gpio{
+	gpio-ranges = <
+		&pinctrl 49  GPIO_49  2
+		&pinctrl 58  GPIO_58  1
+		&pinctrl 63  GPIO_63  1
+		/*&pinctrl 65  GPIO_65  1 */
+		&pinctrl 67  GPIO_67  1
+		&pinctrl 70  PRI_TDI  4
+		/*&pinctrl 74  GPIO_74  1*/
+		&pinctrl 79  GPIO_79  1
+		&pinctrl 80  GPIO_80  4
+		&pinctrl 90  GPIO_90  3
+		&pinctrl 96  DVL0     2
+		&pinctrl 110 GPIO_110 1
+		&pinctrl 111 GPIO_111 1
+		&pinctrl 113 GPIO_113 1
+		&pinctrl 114 GPIO_114 3
+		&pinctrl 118 GPIO_118 1
+		&pinctrl 123 GPIO_123 5
+	>;
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart0_2>;
+	status = "okay";
+};
+
+&uart2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart2>;
+	status = "okay";
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_i2c0>;
+	spacemit,i2c-fast-mode;
+	status = "okay";
+};
+
+&i2c1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_i2c1>;
+	spacemit,i2c-fast-mode;
+	status = "okay";
+};
+
+&i2c8 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_i2c8>;
+	status = "okay";
+
+	spmp1@41 {
+		compatible = "spacemit,p1";
+		reg = <0x41>;
+		interrupt-parent = <&intc>;
+		interrupts = <64>;
+		status = "okay";
+
+		regulators {
+			compatible = "spacemit,p1,regulator";
+
+			/* buck */
+			dcdc_1: DCDC_REG1 {
+				regulator-name = "dcdc1";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3450000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <650000>;
+				};
+			};
+
+			dcdc_2: DCDC_REG2 {
+				regulator-name = "dcdc2";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3450000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+			};
+
+			dcdc_3: DCDC_REG3 {
+				regulator-name = "dcdc3";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <1800000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+			};
+
+			dcdc_4: DCDC_REG4 {
+				regulator-name = "dcdc4";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <3300000>;
+				};
+			};
+
+			dcdc_5: DCDC_REG5 {
+				regulator-name = "dcdc5";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3450000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+			};
+
+			dcdc_6: DCDC_REG6 {
+				regulator-name = "dcdc6";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3450000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+			};
+
+			/* aldo */
+			ldo_1: LDO_REG1 {
+				regulator-name = "ldo1";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+				regulator-boot-on;
+
+				/* set the min voltage means will disable this vol in suspend for ldo */
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_2: LDO_REG2 {
+				regulator-name = "ldo2";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_3: LDO_REG3 {
+				regulator-name = "ldo3";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_4: LDO_REG4 {
+				regulator-name = "ldo4";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			/* dldo */
+			ldo_5: LDO_REG5 {
+				regulator-name = "ldo5";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+				regulator-boot-on;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_6: LDO_REG6 {
+				regulator-name = "ldo6";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_7: LDO_REG7 {
+				regulator-name = "ldo7";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_8: LDO_REG8 {
+				regulator-name = "ldo8";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+				regulator-always-on;
+			};
+
+			ldo_9: LDO_REG9 {
+				regulator-name = "ldo9";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+			};
+
+			ldo_10: LDO_REG10 {
+				regulator-name = "ldo10";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+				regulator-always-on;
+			};
+
+			ldo_11: LDO_REG11 {
+				regulator-name = "ldo11";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+			};
+
+			sw_1: SWITCH_REG1 {
+				regulator-boot-on;
+				regulator-always-on;
+				regulator-name = "switch1";
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+		};
+
+		pmic_pinctrl: pinctrl {
+			compatible = "spacemit,p1,pinctrl";
+			gpio-controller;
+			#gpio-cells = <2>;
+			spm_pmic,npins = <6>;
+		};
+
+		pwr_key: key {
+			compatible = "spacemit,p1,pwrkey";
+		};
+
+		ext_rtc: rtc {
+			compatible = "spacemit,p1,rtc";
+		};
+
+		ext_adc: adc {
+			compatible = "spacemit,p1,adc";
+		};
+	};
+};
+
+/* SD */
+&sdhci0 {
+	pinctrl-names = "default","fast";
+	pinctrl-0 = <&pinctrl_mmc1>;
+	pinctrl-1 = <&pinctrl_mmc1_fast>;
+	bus-width = <4>;
+	cd-gpios = <&gpio 80 0>;
+	cd-inverted;
+	vmmc-supply = <&dcdc_4>;
+	vqmmc-supply = <&ldo_1>;
+	no-mmc;
+	no-sdio;
+	spacemit,sdh-host-caps-disable = <(
+			MMC_CAP_UHS_SDR12 |
+			MMC_CAP_UHS_SDR25
+			)>;
+	spacemit,sdh-quirks = <(
+			SDHCI_QUIRK_BROKEN_CARD_DETECTION |
+			SDHCI_QUIRK_INVERTED_WRITE_PROTECT |
+			SDHCI_QUIRK_BROKEN_TIMEOUT_VAL
+			)>;
+	spacemit,sdh-quirks2 = <(
+			SDHCI_QUIRK2_PRESET_VALUE_BROKEN |
+			SDHCI_QUIRK2_BROKEN_PHY_MODULE |
+			SDHCI_QUIRK2_SET_AIB_MMC
+			)>;
+	spacemit,aib_mmc1_io_reg = <0xD401E81C>;
+	spacemit,apbc_asfar_reg = <0xD4015050>;
+	spacemit,apbc_assar_reg = <0xD4015054>;
+	spacemit,rx_dline_reg = <0x0>;
+	spacemit,tx_dline_reg = <0x0>;
+	spacemit,tx_delaycode = <0x9f>;
+	spacemit,rx_tuning_limit = <50>;
+	spacemit,sdh-freq = <204800000>;
+	status = "okay";
+};
+
+/* SDIO */
+&sdhci1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_mmc2>;
+	bus-width = <4>;
+	non-removable;
+	vqmmc-supply = <&dcdc_3>;
+	no-mmc;
+	no-sd;
+	keep-power-in-suspend;
+	/* bcmdhd use private oob solution rather than dat1/standard wakeup */
+	/delete-property/ enable-sdio-wakeup;
+	spacemit,sdh-host-caps-disable = <(
+			MMC_CAP_UHS_DDR50 |
+			MMC_CAP_NEEDS_POLL
+			)>;
+	spacemit,sdh-quirks = <(
+			SDHCI_QUIRK_BROKEN_CARD_DETECTION |
+			SDHCI_QUIRK_BROKEN_TIMEOUT_VAL
+			)>;
+	spacemit,sdh-quirks2 = <(
+			SDHCI_QUIRK2_PRESET_VALUE_BROKEN |
+			SDHCI_QUIRK2_BROKEN_PHY_MODULE
+			)>;
+	spacemit,rx_dline_reg = <0x0>;
+	spacemit,tx_delaycode = <0x9f>;
+	spacemit,rx_tuning_limit = <50>;
+	spacemit,sdh-freq = <375000000>;
+	status = "okay";
+};
+
+/* eMMC */
+&sdhci2 {
+	bus-width = <8>;
+	non-removable;
+	mmc-hs400-1_8v;
+	mmc-hs400-enhanced-strobe;
+	no-sd;
+	no-sdio;
+	spacemit,sdh-quirks = <(
+			SDHCI_QUIRK_BROKEN_CARD_DETECTION |
+			SDHCI_QUIRK_BROKEN_TIMEOUT_VAL
+			)>;
+	spacemit,sdh-quirks2 = <(
+			SDHCI_QUIRK2_PRESET_VALUE_BROKEN
+			)>;
+	spacemit,sdh-freq = <375000000>;
+	status = "okay";
+};
+
+&eth0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_gmac0>;
+
+	emac,reset-gpio = <&gpio 110 0>;
+	emac,reset-active-low;
+	emac,reset-delays-us = <0 10000 100000>;
+
+	tx-threshold = <1518>;
+	rx-threshold = <12>;
+	tx-ring-num = <1024>;
+	rx-ring-num = <1024>;
+	dma-burst-len = <5>;
+
+	ref-clock-from-phy;
+
+	clk-tuning-enable;
+	clk-tuning-by-delayline;
+	tx-phase = <60>;
+	rx-phase = <73>;
+
+	phy-handle = <&rgmii0>;
+
+	status = "okay";
+
+	mdio-bus {
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+		rgmii0: phy@0 {
+			compatible = "ethernet-phy-id4f51.e91b";
+			device_type = "ethernet-phy";
+			reg = <0x1>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&eth1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_gmac1>;
+
+	emac,reset-gpio = <&gpio 115 0>;
+	emac,reset-active-low;
+	emac,reset-delays-us = <0 10000 100000>;
+
+	tx-threshold = <1518>;
+	rx-threshold = <12>;
+	tx-ring-num = <1024>;
+	rx-ring-num = <1024>;
+	dma-burst-len = <5>;
+
+	ref-clock-from-phy;
+
+	clk-tuning-enable;
+	clk-tuning-by-delayline;
+	tx-phase = <90>;
+	rx-phase = <73>;
+
+	phy-handle = <&rgmii1>;
+
+	status = "okay";
+
+	mdio-bus {
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+		rgmii1: phy@1 {
+			compatible = "ethernet-phy-id4f51.e91b";
+			device_type = "ethernet-phy";
+			reg = <0x1>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&qspi {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_qspi>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <26500000>;
+		m25p,fast-read;
+		broken-flash-reset;
+		status = "okay";
+	};
+};

--- a/arch/riscv/boot/dts/spacemit/x1-orange-pi-rv2.dts
+++ b/arch/riscv/boot/dts/spacemit/x1-orange-pi-rv2.dts
@@ -1,0 +1,531 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/* Copyright (c) 2026 ChuanN, Inc */
+
+/dts-v1/;
+
+#include "k1.dtsi"
+#include "k1_pinctrl.dtsi"
+
+/ {
+	model = "OrangePi RV2";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x00000000 0x0 0x80000000>;
+	};
+
+	memory@100000000 {
+		device_type = "memory";
+		reg = <0x1 0x00000000 0x0 0x80000000>;
+	};
+
+	chosen {
+		bootargs = "earlycon=sbi console=ttyS0,115200n8 loglevel=8 rdinit=/init";
+		stdout-path = "serial0:115200n8";
+	};
+
+	dc_12v: dc-12v {
+		compatible = "regulator-fixed";
+		regulator-name = "dc_12v";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <12000000>;
+		regulator-max-microvolt = <12000000>;
+	};
+
+	vcc4v0_baseboard: vcc4v0-baseboard {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc4v0_baseboard";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <4000000>;
+		regulator-max-microvolt = <4000000>;
+		vin-supply = <&dc_12v>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led1 {
+			label = "sys-led";
+			gpios = <&gpio 96 0>;
+			linux,default-trigger = "heartbeat";
+			default-state = "on";
+			status = "okay";
+		};
+	};
+
+	ap6256_wifi: ap6256_wifi {
+		compatible = "android,bcmdhd_wlan";
+		gpio_wl_reg_on = <&gpio 67 0>;
+	};
+};
+
+&pinctrl {
+	pinctrl-single,gpio-range = <
+		&range GPIO_49  2 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_3V_DS4)
+		&range GPIO_58  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_63  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_64  1 (MUX_MODE1 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_65  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_67  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_3V_DS4)
+		&range PRI_TDI  2 (MUX_MODE1 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range PRI_TCK  1 (MUX_MODE1 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range PRI_TDO  1 (MUX_MODE1 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		/*&range GPIO_74  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2) */
+		&range GPIO_79  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_80  1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_3V_DS4)
+		&range GPIO_81  3 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_90  1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_91  2 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range DVL0     1 (MUX_MODE1 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range DVL1     1 (MUX_MODE1 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS0)
+		&range GPIO_110 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_111 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_113 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_114 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_115 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+		&range GPIO_116 1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_118 1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_123 1 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS0)
+		&range GPIO_124 1 (MUX_MODE0 | EDGE_NONE | PULL_UP   | PAD_1V8_DS2)
+		&range GPIO_125 3 (MUX_MODE0 | EDGE_NONE | PULL_DOWN | PAD_1V8_DS2)
+	>;
+};
+
+&gpio{
+	gpio-ranges = <
+		&pinctrl 49  GPIO_49  2
+		&pinctrl 58  GPIO_58  1
+		&pinctrl 63  GPIO_63  1
+		/*&pinctrl 65  GPIO_65  1 */
+		&pinctrl 67  GPIO_67  1
+		&pinctrl 70  PRI_TDI  4
+		/*&pinctrl 74  GPIO_74  1*/
+		&pinctrl 79  GPIO_79  1
+		&pinctrl 80  GPIO_80  4
+		&pinctrl 90  GPIO_90  3
+		&pinctrl 96  DVL0     2
+		&pinctrl 110 GPIO_110 1
+		&pinctrl 111 GPIO_111 1
+		&pinctrl 113 GPIO_113 1
+		&pinctrl 114 GPIO_114 3
+		&pinctrl 118 GPIO_118 1
+		&pinctrl 123 GPIO_123 5
+	>;
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart0_2>;
+	status = "okay";
+};
+
+&uart2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart2>;
+	status = "okay";
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_i2c0>;
+	spacemit,i2c-fast-mode;
+	status = "okay";
+};
+
+&i2c1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_i2c1>;
+	spacemit,i2c-fast-mode;
+	status = "okay";
+};
+
+&i2c8 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_i2c8>;
+	status = "okay";
+
+	spmp1@41 {
+		compatible = "spacemit,p1";
+		reg = <0x41>;
+		interrupt-parent = <&intc>;
+		interrupts = <64>;
+		status = "okay";
+
+		regulators {
+			compatible = "spacemit,p1,regulator";
+
+			/* buck */
+			dcdc_1: DCDC_REG1 {
+				regulator-name = "dcdc1";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3450000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <650000>;
+				};
+			};
+
+			dcdc_2: DCDC_REG2 {
+				regulator-name = "dcdc2";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3450000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+			};
+
+			dcdc_3: DCDC_REG3 {
+				regulator-name = "dcdc3";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <1800000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+			};
+
+			dcdc_4: DCDC_REG4 {
+				regulator-name = "dcdc4";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <3300000>;
+				};
+			};
+
+			dcdc_5: DCDC_REG5 {
+				regulator-name = "dcdc5";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3450000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+			};
+
+			dcdc_6: DCDC_REG6 {
+				regulator-name = "dcdc6";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3450000>;
+				regulator-ramp-delay = <5000>;
+				regulator-always-on;
+			};
+
+			/* aldo */
+			ldo_1: LDO_REG1 {
+				regulator-name = "ldo1";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+				regulator-boot-on;
+
+				/* set the min voltage means will disable this vol in suspend for ldo */
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_2: LDO_REG2 {
+				regulator-name = "ldo2";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_3: LDO_REG3 {
+				regulator-name = "ldo3";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_4: LDO_REG4 {
+				regulator-name = "ldo4";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			/* dldo */
+			ldo_5: LDO_REG5 {
+				regulator-name = "ldo5";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+				regulator-boot-on;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_6: LDO_REG6 {
+				regulator-name = "ldo6";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_7: LDO_REG7 {
+				regulator-name = "ldo7";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <500000>;
+				};
+			};
+
+			ldo_8: LDO_REG8 {
+				regulator-name = "ldo8";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+				regulator-always-on;
+			};
+
+			ldo_9: LDO_REG9 {
+				regulator-name = "ldo9";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+			};
+
+			ldo_10: LDO_REG10 {
+				regulator-name = "ldo10";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+				regulator-always-on;
+			};
+
+			ldo_11: LDO_REG11 {
+				regulator-name = "ldo11";
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <3400000>;
+			};
+
+			sw_1: SWITCH_REG1 {
+				regulator-boot-on;
+				regulator-always-on;
+				regulator-name = "switch1";
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+		};
+
+		pmic_pinctrl: pinctrl {
+			compatible = "spacemit,p1,pinctrl";
+			gpio-controller;
+			#gpio-cells = <2>;
+			spm_pmic,npins = <6>;
+		};
+
+		pwr_key: key {
+			compatible = "spacemit,p1,pwrkey";
+		};
+
+		ext_rtc: rtc {
+			compatible = "spacemit,p1,rtc";
+		};
+
+		ext_adc: adc {
+			compatible = "spacemit,p1,adc";
+		};
+	};
+};
+
+/* SD */
+&sdhci0 {
+	pinctrl-names = "default","fast";
+	pinctrl-0 = <&pinctrl_mmc1>;
+	pinctrl-1 = <&pinctrl_mmc1_fast>;
+	bus-width = <4>;
+	cd-gpios = <&gpio 80 0>;
+	cd-inverted;
+	vmmc-supply = <&dcdc_4>;
+	vqmmc-supply = <&ldo_1>;
+	no-mmc;
+	no-sdio;
+	spacemit,sdh-host-caps-disable = <(
+			MMC_CAP_UHS_SDR12 |
+			MMC_CAP_UHS_SDR25
+			)>;
+	spacemit,sdh-quirks = <(
+			SDHCI_QUIRK_BROKEN_CARD_DETECTION |
+			SDHCI_QUIRK_INVERTED_WRITE_PROTECT |
+			SDHCI_QUIRK_BROKEN_TIMEOUT_VAL
+			)>;
+	spacemit,sdh-quirks2 = <(
+			SDHCI_QUIRK2_PRESET_VALUE_BROKEN |
+			SDHCI_QUIRK2_BROKEN_PHY_MODULE |
+			SDHCI_QUIRK2_SET_AIB_MMC
+			)>;
+	spacemit,aib_mmc1_io_reg = <0xD401E81C>;
+	spacemit,apbc_asfar_reg = <0xD4015050>;
+	spacemit,apbc_assar_reg = <0xD4015054>;
+	spacemit,rx_dline_reg = <0x0>;
+	spacemit,tx_dline_reg = <0x0>;
+	spacemit,tx_delaycode = <0x9f>;
+	spacemit,rx_tuning_limit = <50>;
+	spacemit,sdh-freq = <204800000>;
+	status = "okay";
+};
+
+/* SDIO */
+&sdhci1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_mmc2>;
+	bus-width = <4>;
+	non-removable;
+	vqmmc-supply = <&dcdc_3>;
+	no-mmc;
+	no-sd;
+	keep-power-in-suspend;
+	/* bcmdhd use private oob solution rather than dat1/standard wakeup */
+	/delete-property/ enable-sdio-wakeup;
+	spacemit,sdh-host-caps-disable = <(
+			MMC_CAP_UHS_DDR50 |
+			MMC_CAP_NEEDS_POLL
+			)>;
+	spacemit,sdh-quirks = <(
+			SDHCI_QUIRK_BROKEN_CARD_DETECTION |
+			SDHCI_QUIRK_BROKEN_TIMEOUT_VAL
+			)>;
+	spacemit,sdh-quirks2 = <(
+			SDHCI_QUIRK2_PRESET_VALUE_BROKEN |
+			SDHCI_QUIRK2_BROKEN_PHY_MODULE
+			)>;
+	spacemit,rx_dline_reg = <0x0>;
+	spacemit,tx_delaycode = <0x9f>;
+	spacemit,rx_tuning_limit = <50>;
+	spacemit,sdh-freq = <375000000>;
+	status = "okay";
+};
+
+/* eMMC */
+&sdhci2 {
+	bus-width = <8>;
+	non-removable;
+	mmc-hs400-1_8v;
+	mmc-hs400-enhanced-strobe;
+	no-sd;
+	no-sdio;
+	spacemit,sdh-quirks = <(
+			SDHCI_QUIRK_BROKEN_CARD_DETECTION |
+			SDHCI_QUIRK_BROKEN_TIMEOUT_VAL
+			)>;
+	spacemit,sdh-quirks2 = <(
+			SDHCI_QUIRK2_PRESET_VALUE_BROKEN
+			)>;
+	spacemit,sdh-freq = <375000000>;
+	status = "okay";
+};
+
+&eth0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_gmac0>;
+
+	emac,reset-gpio = <&gpio 110 0>;
+	emac,reset-active-low;
+	emac,reset-delays-us = <0 10000 100000>;
+
+	tx-threshold = <1518>;
+	rx-threshold = <12>;
+	tx-ring-num = <1024>;
+	rx-ring-num = <1024>;
+	dma-burst-len = <5>;
+
+	ref-clock-from-phy;
+
+	clk-tuning-enable;
+	clk-tuning-by-delayline;
+	tx-phase = <60>;
+	rx-phase = <73>;
+
+	phy-handle = <&rgmii0>;
+
+	status = "okay";
+
+	mdio-bus {
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+		rgmii0: phy@0 {
+			compatible = "ethernet-phy-id4f51.e91b";
+			device_type = "ethernet-phy";
+			reg = <0x1>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&eth1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_gmac1>;
+
+	emac,reset-gpio = <&gpio 115 0>;
+	emac,reset-active-low;
+	emac,reset-delays-us = <0 10000 100000>;
+
+	tx-threshold = <1518>;
+	rx-threshold = <12>;
+	tx-ring-num = <1024>;
+	rx-ring-num = <1024>;
+	dma-burst-len = <5>;
+
+	ref-clock-from-phy;
+
+	clk-tuning-enable;
+	clk-tuning-by-delayline;
+	tx-phase = <90>;
+	rx-phase = <73>;
+
+	phy-handle = <&rgmii1>;
+
+	status = "okay";
+
+	mdio-bus {
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+		rgmii1: phy@1 {
+			compatible = "ethernet-phy-id4f51.e91b";
+			device_type = "ethernet-phy";
+			reg = <0x1>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&qspi {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_qspi>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <26500000>;
+		m25p,fast-read;
+		broken-flash-reset;
+		status = "okay";
+	};
+};


### PR DESCRIPTION
fixed: #248

为 SpacemiT MUSE Pi Pro、SpacemiT MUSE Pi、Milk-V Jupiter以及OrangePi RV2 添加设备树支持。

该设备树已在 openEuler 24.03 上完成基础测试，
其中 sdhci、eth0、eth1、LED、tty等功能已验证正常。
i2c、spi 、qspi目前完成了基础枚举测试，可正常识别总线设备。

另外，在 eth0 的 MDIO PHY 节点描述中发现一处潜在不一致：
当前节点名为 phy@0，但 reg 配置为 <0x1>。
按设备树节点命名规范，其 unit-address 应与 reg 保持一致，理论上应为 phy@1。
目前该配置下网口功能可正常使用，因此本次暂未修改，后续待进一步确认后再处理。
