### PR TITLE
riscv: add hardware error trap handler support

### DIFF
--- a/arch/riscv/include/asm/asm-prototypes.h
+++ b/arch/riscv/include/asm/asm-prototypes.h
@@ -40,6 +40,7 @@ asmlinkage void riscv_v_context_nesting_end(struct pt_regs *regs);
 #define DECLARE_DO_ERROR_INFO(name)	asmlinkage void name(struct pt_regs *regs)
 
 DECLARE_DO_ERROR_INFO(do_trap_unknown);
+DECLARE_DO_ERROR_INFO(do_trap_hardware_error);
 DECLARE_DO_ERROR_INFO(do_trap_insn_misaligned);
 DECLARE_DO_ERROR_INFO(do_trap_insn_fault);
 DECLARE_DO_ERROR_INFO(do_trap_insn_illegal);

--- a/arch/riscv/kernel/entry.S
+++ b/arch/riscv/kernel/entry.S
@@ -406,6 +406,10 @@ SYM_DATA_START_LOCAL(excp_vect_table)
 	RISCV_PTR do_page_fault   /* load page fault */
 	RISCV_PTR do_trap_unknown
 	RISCV_PTR do_page_fault   /* store page fault */
+	RISCV_PTR do_trap_unknown /* double trap */
+	RISCV_PTR do_trap_unknown
+	RISCV_PTR do_trap_unknown /* software check error */
+	RISCV_PTR do_trap_hardware_error /* hardware error (19) */
 SYM_DATA_END_LABEL(excp_vect_table, SYM_L_LOCAL, excp_vect_table_end)
 
 #ifndef CONFIG_MMU

--- a/arch/riscv/kernel/traps.c
+++ b/arch/riscv/kernel/traps.c
@@ -147,6 +147,8 @@ asmlinkage __visible __trap_section void name(struct pt_regs *regs)		\
 
 DO_ERROR_INFO(do_trap_unknown,
 	SIGILL, ILL_ILLTRP, "unknown exception");
+DO_ERROR_INFO(do_trap_hardware_error,
+	SIGBUS, BUS_MCEERR_AR, "hardware error");
 DO_ERROR_INFO(do_trap_insn_misaligned,
 	SIGBUS, BUS_ADRALN, "instruction address misaligned");
 DO_ERROR_INFO(do_trap_insn_fault,


### PR DESCRIPTION
fixed: #269

riscv: add hardware error trap handler support
community inclusion
category: feature
bugzilla: https://github.com/RVCK-Project/rvck/issues/269
Reference: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=next-20260413&id=5d5c5d0f2be9cf0351ad8e90516c519a8db22981

---------------------------

Add support for handling hardware error traps (exception code 19)
in the RISC-V architecture. The changes include:

- Add do_trap_hardware_error function declaration in asm-prototypes.h
- Add hardware error trap vector entry in entry.S exception vector table
- Implement do_trap_hardware_error handler in traps.c that generates
  SIGBUS with BUS_MCEERR_AR for hardware errors

This enables proper handling of hardware error exceptions that may occur
in RISC-V systems, providing appropriate error reporting and signal
generation for user space processes.

Signed-off-by: Rui Qi <qirui.001@bytedance.com>
Link: https://patch.msgid.link/20260202094200.53735-1-qirui.001@bytedance.com
[pjw@kernel.org: clean up commit message slightly]
Signed-off-by: Paul Walmsley <pjw@kernel.org>
Signed-off-by: Lu Peng <lu.peng3@zte.com.cn>
Signed-off-by: liuqingtao <liu.qingtao2@zte.com.cn>