### PR TITLE
tmpfs: don't enable large folios if not supported

### DIFF
--- a/mm/shmem.c
+++ b/mm/shmem.c
@@ -2493,7 +2493,10 @@ static struct inode *__shmem_get_inode(struct mnt_idmap *idmap,
 		mapping_set_unevictable(inode->i_mapping);
 	simple_xattrs_init(&info->xattrs);
 	cache_no_acl(inode);
-	mapping_set_large_folios(inode->i_mapping);
+
+	/* Don't consider 'deny' for emergencies and 'force' for testing */
+	if (sbinfo->huge)
+		mapping_set_large_folios(inode->i_mapping);
 
 	switch (mode & S_IFMT) {
 	default:


### PR DESCRIPTION
fixed: #277

tmpfs: don't enable large folios if not supported

mainline inclusion
from mainline-v6.13-rc1
commit 5a90c155defa684f3a21f68c3f8e40c056e6114c
category: bugfix
bugzilla: https://github.com/RVCK-Project/rvck/issues/277

Reference: https://github.com/torvalds/linux/commit/5a90c155defa684f3a21f68c3f8e40c056e6114c

--------------------------------

The performance improvement of writing to tmpfs via fio becomes more significant as the block size increases. When the block size (BS) is small, the performance advantage isn't obvious and the data tends to fluctuate. However, with a larger BS, a clear advantage can still be observed even if there is some data fluctuation.

Tested on qemu-system-riscv64, vcpu=1, mem=16G.
Test command:
1.dd if=/dev/zero of=/mnt/tmpfs_test/test_file bs=1M count=1024 2.fio --name=seqwrite --filename=/mnt/test_file \
--rw=write --bs=?M \ --size=1G --direct=1 --numjobs=1 --time_based --runtime=30 --group_reporting

```
bs(MiB)	Repetition	before(MiB/s)	after(MiB/s)	improvement
bs=2M	1			1077			1061			-1.49%
		2			1170			1109			-5.21%
		3			1106			1104			-0.18%
		4			1101			1155			+4.90%
bs=4M	1			1196			1132			-5.35%
		2			1222			1092			-10.63%
		3			1203			1200			-0.25%
		4			1228			1445			+17.67%
bs=8M	1			1406			1611			+14.58%
		2			1278			1517			+22.93%
		3			1484			1564			+5.39%
		4			1503			1562			+3.93%
bs=16M	1			1551			1656			+6.77%
		2			1531			1638			+6.99%
		3			1578			1671			+5.89%
		4			1560			1603			+2.76%
```
original changelog

tmpfs: don't enable large folios if not supported
tmpfs can support large folios, but there are some configurable options (mount options and runtime deny/force) to enable/disable large folio allocation, so there is a performance issue when performing writes without large folios.  The issue is similar to commit 4e527d5 ("iomap: fault in smaller chunks for non-large folio mappings").

Since 'deny' is for emergencies and 'force' is for testing, performance issues should not be a problem in real production environments, so don't call mapping_set_large_folios() in __shmem_get_inode() when large folio is disabled with mount huge=never option (default policy).

Link: https://lkml.kernel.org/r/20241017141742.1169404-1-wangkefeng.wang@huawei.com
Fixes: 9aac777 ("filemap: Convert generic_perform_write() to support large folios")

Cc: Alexander Viro <viro@zeniv.linux.org.uk>
Cc: Baolin Wang <baolin.wang@linux.alibaba.com>
Cc: Christian Brauner <brauner@kernel.org>
Cc: David Hildenbrand <david@redhat.com>
Cc: Hugh Dickins <hughd@google.com>
Cc: Jan Kara <jack@suse.cz>
Cc: Matthew Wilcox <willy@infradead.org>
Signed-off-by: Andrew Morton <akpm@linux-foundation.org>
Signed-off-by: Yang Susheng <yang.susheng@zte.com.cn>
Signed-off-by: Liu Qingtao <liu.qingtao2@zte.com.cn>