### PR TITLE
riscv: Fix incorrect use of REG_L for 32-bit types in sse_entry.S

### DIFF
--- a/arch/riscv/kernel/sse_entry.S
+++ b/arch/riscv/kernel/sse_entry.S
@@ -100,8 +100,8 @@ SYM_CODE_START(handle_sse)
 	mv t3, zero
 
 #ifdef CONFIG_SMP
-	REG_L t4, SSE_REG_HART_ID(a7)
-	REG_L t3, SSE_REG_CPU_ID(a7)
+	lw t4, SSE_REG_HART_ID(a7)
+	lw t3, SSE_REG_CPU_ID(a7)
 
 	bne t4, a6, .Lfind_hart_id_slowpath
 


### PR DESCRIPTION
fixed: #288

community inclusion
category: bugfix
bugzilla: https://github.com/RVCK-Project/rvck/issues/288

--------------------------------

The REG_L macro was mistakenly used to handle 32-bit data types. Changed it to lw.

This bug previously caused the SSE handling flow to incorrectly take the slow path, and some cores were unable to enter the SSE processing flow at all.